### PR TITLE
feat: fixed windows for routes and booking requests

### DIFF
--- a/packages/engine-elixir/lib/bookingRequests.ex
+++ b/packages/engine-elixir/lib/bookingRequests.ex
@@ -1,19 +1,16 @@
 defmodule BookingRequests do
   def init do
-    IO.puts("Initialize the stream for booking requests")
-
-    Stream.resource(
-      fn -> subscribe(self()) end,
-      fn pid -> receive_next_value(pid) end,
-      fn values -> values end
-    )
+    IO.puts("Initialize the booking requests SUBSCRIBER")
+    {:ok, agent} = Agent.start_link(fn -> [] end)
+    subscribe(agent)
+    agent
   end
 
   defp decode(booking) do
     booking |> Poison.decode!(%{keys: :atoms})
   end
 
-  defp subscribe(parent) do
+  defp subscribe(agent) do
     IO.puts("Subscribe for bookings")
 
     spawn(fn ->
@@ -28,21 +25,11 @@ defmodule BookingRequests do
       IO.puts("Now we bound the #{queue} to bookings exchange")
 
       AMQP.Queue.subscribe(channel, queue, fn booking, _meta ->
-        IO.puts("Now we have a message from booking_requests queue")
+        # IO.puts("Now we have a message from booking_requests queue")
         booking_decoded = decode(booking)
-        IO.puts("Got info about booking #{booking_decoded.id}")
-        send(parent, {:msg, booking: booking_decoded})
+        # IO.puts("Got info about booking #{booking_decoded.id}")
+        Agent.update(agent, fn bookings -> bookings ++ [booking_decoded] end)
       end)
     end)
-  end
-
-  defp receive_next_value(pid) do
-    receive do
-      {:msg, booking: booking} ->
-        {[booking], pid}
-
-      _ ->
-        receive_next_value(pid)
-    end
   end
 end

--- a/packages/engine-elixir/lib/bookingRequests.ex
+++ b/packages/engine-elixir/lib/bookingRequests.ex
@@ -1,27 +1,30 @@
 defmodule BookingRequests do
   def init do
-    parent = self()
-
     Stream.resource(
-      fn ->
-        spawn(fn ->
-          queue_name = "booking_requests"
-          # Application.fetch_env!(:engine, :bookings_exchange)
-          bookings_exchange = "bookings"
-          {:ok, connection} = AMQP.Connection.open(Application.fetch_env!(:engine, :amqp_host))
-          {:ok, channel} = AMQP.Channel.open(connection)
-          AMQP.Exchange.declare(channel, bookings_exchange, :topic)
-          AMQP.Queue.declare(channel, queue_name)
-          AMQP.Queue.bind(channel, queue_name, bookings_exchange, routing_key: "new")
-
-          AMQP.Queue.subscribe(channel, queue_name, fn booking, _meta ->
-            send(parent, {:msg, booking: booking |> Poison.decode!(%{keys: :atoms})})
-          end)
-        end)
-      end,
+      fn -> subscribe(self()) end,
       fn pid -> receive_next_value(pid) end,
       fn values -> values end
     )
+  end
+
+  defp decode(booking) do
+    booking |> Poison.decode!(%{keys: :atoms})
+  end
+
+  defp subscribe(parent) do
+    spawn(fn ->
+      exchange = "bookings"
+      queue = "booking_requests"
+      {:ok, connection} = AMQP.Connection.open(Application.fetch_env!(:engine, :amqp_host))
+      {:ok, channel} = AMQP.Channel.open(connection)
+      AMQP.Exchange.declare(channel, exchange, :topic)
+      AMQP.Queue.declare(channel, queue)
+      AMQP.Queue.bind(channel, queue, exchange, routing_key: "new")
+
+      AMQP.Queue.subscribe(channel, queue, fn booking, _meta ->
+        send(parent, {:msg, booking: decode(booking)})
+      end)
+    end)
   end
 
   defp receive_next_value(pid) do

--- a/packages/engine-elixir/lib/bookingRequests.ex
+++ b/packages/engine-elixir/lib/bookingRequests.ex
@@ -1,5 +1,7 @@
 defmodule BookingRequests do
   def init do
+    IO.puts("Initialize the stream for booking requests")
+
     Stream.resource(
       fn -> subscribe(self()) end,
       fn pid -> receive_next_value(pid) end,
@@ -12,16 +14,21 @@ defmodule BookingRequests do
   end
 
   defp subscribe(parent) do
+    IO.puts("Subscribe for bookings")
+
     spawn(fn ->
       exchange = "bookings"
       queue = "booking_requests"
+      IO.puts("Now we create a #{queue} for bookings exchange")
       {:ok, connection} = AMQP.Connection.open(Application.fetch_env!(:engine, :amqp_host))
       {:ok, channel} = AMQP.Channel.open(connection)
       AMQP.Exchange.declare(channel, exchange, :topic)
       AMQP.Queue.declare(channel, queue)
       AMQP.Queue.bind(channel, queue, exchange, routing_key: "new")
+      IO.puts("Now we bound the #{queue} to bookings exchange")
 
       AMQP.Queue.subscribe(channel, queue, fn booking, _meta ->
+        IO.puts("Now we have a message from booking_requests queue")
         booking_decoded = decode(booking)
         IO.puts("Got info about booking #{booking_decoded.id}")
         send(parent, {:msg, booking: booking_decoded})

--- a/packages/engine-elixir/lib/bookingRequests.ex
+++ b/packages/engine-elixir/lib/bookingRequests.ex
@@ -22,7 +22,9 @@ defmodule BookingRequests do
       AMQP.Queue.bind(channel, queue, exchange, routing_key: "new")
 
       AMQP.Queue.subscribe(channel, queue, fn booking, _meta ->
-        send(parent, {:msg, booking: decode(booking)})
+        booking_decoded = decode(booking)
+        IO.puts("Got info about booking #{booking_decoded.id}")
+        send(parent, {:msg, booking: booking_decoded})
       end)
     end)
   end

--- a/packages/engine-elixir/lib/dispatch.ex
+++ b/packages/engine-elixir/lib/dispatch.ex
@@ -17,24 +17,25 @@ defmodule Dispatch do
     end)
     # divide into separate branches and evaluate them in parallell
     # TODO: Revert to this code when YOU understand how Flow works
-    # |> Flow.from_enumerable()
-    # |> Flow.partition(key: fn %{car: car} -> car.id end)
-    # |> Flow.map(fn %{booking: booking, car: car} -> ask_driver.(car, booking) end)
-    # |> Flow.filter(fn %{accepted: accepted} -> accepted end)
-    # |> Flow.map(fn %{booking: booking, car: car} ->
-    #   IO.puts("Car #{car.id} accepted booking #{booking.id}")
-    #   assign_booking.(booking, car)
-    # end)
-
-    |> Enum.map(fn %{booking: booking, car: car} ->
-      IO.puts("asking the driver")
-      ask_driver.(car, booking)
-    end)
-    |> Enum.filter(fn %{accepted: accepted} -> accepted == "true" end)
-    |> Enum.map(fn %{booking: booking, car: car} ->
+    |> Flow.from_enumerable()
+    |> Flow.partition(key: fn %{car: car} -> car.id end)
+    |> Flow.map(fn %{booking: booking, car: car} -> ask_driver.(car, booking) end)
+    |> Flow.filter(fn %{accepted: accepted} -> accepted == "true" end)
+    |> Flow.map(fn %{booking: booking, car: car} ->
       IO.puts("Car #{car.id} accepted booking #{booking.id}")
       assign_booking.(booking, car)
     end)
+    |> Enum.to_list()
+
+    # |> Enum.map(fn %{booking: booking, car: car} ->
+    #   IO.puts("asking the driver")
+    #   ask_driver.(car, booking)
+    # end)
+    # |> Enum.filter(fn %{accepted: accepted} -> accepted == "true" end)
+    # |> Enum.map(fn %{booking: booking, car: car} ->
+    #   IO.puts("Car #{car.id} accepted booking #{booking.id}")
+    #   assign_booking.(booking, car)
+    # end)
   end
 
   def find_candidates(bookings, cars) do

--- a/packages/engine-elixir/lib/dispatch.ex
+++ b/packages/engine-elixir/lib/dispatch.ex
@@ -5,11 +5,16 @@ defmodule Dispatch do
   end
 
   def find_and_offer_cars(batch_of_bookings, batch_of_cars, ask_driver, assign_booking) do
+    IO.puts("will now try to find and offer cars")
+
     Stream.zip(batch_of_bookings, batch_of_cars)
     |> Stream.flat_map(fn {latest_bookings, latest_cars} ->
       find_candidates(latest_bookings, latest_cars)
     end)
-    |> Stream.filter(fn %{booking: booking, car: car} -> Dispatch.evaluate(booking, car) end)
+    |> Stream.filter(fn %{booking: booking, car: car} ->
+      IO.puts("evaluating candidates")
+      Dispatch.evaluate(booking, car)
+    end)
     # divide into separate branches and evaluate them in parallell
     # TODO: Revert to this code when YOU understand how Flow works
     # |> Flow.from_enumerable()
@@ -21,7 +26,10 @@ defmodule Dispatch do
     #   assign_booking.(booking, car)
     # end)
 
-    |> Stream.map(fn %{booking: booking, car: car} -> ask_driver.(car, booking) end)
+    |> Stream.map(fn %{booking: booking, car: car} ->
+      IO.puts("asking the driver")
+      ask_driver.(car, booking)
+    end)
     |> Stream.filter(fn %{accepted: accepted} -> accepted == "true" end)
     |> Stream.map(fn %{booking: booking, car: car} ->
       IO.puts("Car #{car.id} accepted booking #{booking.id}")
@@ -30,6 +38,8 @@ defmodule Dispatch do
   end
 
   def find_candidates(bookings, cars) do
+    IO.puts("finding candidates")
+
     bookings
     |> Enum.reduce(%{cars: cars, assignments: [], score: 0}, fn booking, result ->
       [candidate | _rest] = CarFinder.find(booking, result.cars)

--- a/packages/engine-elixir/lib/dispatch.ex
+++ b/packages/engine-elixir/lib/dispatch.ex
@@ -7,11 +7,11 @@ defmodule Dispatch do
   def find_and_offer_cars(batch_of_bookings, batch_of_cars, ask_driver, assign_booking) do
     IO.puts("will now try to find and offer cars")
 
-    Stream.zip(batch_of_bookings, batch_of_cars)
-    |> Stream.flat_map(fn {latest_bookings, latest_cars} ->
+    Enum.zip(batch_of_bookings, batch_of_cars)
+    |> Enum.flat_map(fn {latest_bookings, latest_cars} ->
       find_candidates(latest_bookings, latest_cars)
     end)
-    |> Stream.filter(fn %{booking: booking, car: car} ->
+    |> Enum.filter(fn %{booking: booking, car: car} ->
       IO.puts("evaluating candidates")
       Dispatch.evaluate(booking, car)
     end)
@@ -26,12 +26,12 @@ defmodule Dispatch do
     #   assign_booking.(booking, car)
     # end)
 
-    |> Stream.map(fn %{booking: booking, car: car} ->
+    |> Enum.map(fn %{booking: booking, car: car} ->
       IO.puts("asking the driver")
       ask_driver.(car, booking)
     end)
-    |> Stream.filter(fn %{accepted: accepted} -> accepted == "true" end)
-    |> Stream.map(fn %{booking: booking, car: car} ->
+    |> Enum.filter(fn %{accepted: accepted} -> accepted == "true" end)
+    |> Enum.map(fn %{booking: booking, car: car} ->
       IO.puts("Car #{car.id} accepted booking #{booking.id}")
       assign_booking.(booking, car)
     end)

--- a/packages/engine-elixir/lib/engine.ex
+++ b/packages/engine-elixir/lib/engine.ex
@@ -33,10 +33,10 @@ defmodule Engine.App do
 
     # todo: add date field to the booking
     booking_window =
-      Flow.Window.fixed(1, :minute, fn _booking -> :os.system_time(:milli_seconds) end)
+      Flow.Window.fixed(15, :second, fn _booking -> :os.system_time(:milli_seconds) end)
 
     # todo: add date field to car position update
-    car_window = Flow.Window.fixed(1, :minute, fn _car -> :os.system_time(:milli_seconds) end)
+    car_window = Flow.Window.fixed(15, :second, fn _car -> :os.system_time(:milli_seconds) end)
 
     batch_of_bookings =
       bookings_stream
@@ -52,7 +52,7 @@ defmodule Engine.App do
       cars_stream
       # sliding window of ten minutes?
       |> Flow.from_enumerable()
-      |> Flow.partition(window: booking_window, stages: 1, max_demand: 1)
+      |> Flow.partition(window: car_window, stages: 1, max_demand: 1)
       |> Flow.reduce(fn -> [] end, fn e, acc -> [e | acc] end)
       |> Flow.departition(fn -> [] end, &(&1 ++ &2), &Enum.sort/1)
 

--- a/packages/engine-elixir/lib/engine.ex
+++ b/packages/engine-elixir/lib/engine.ex
@@ -33,16 +33,16 @@ defmodule Engine.App do
 
     # todo: add date field to the booking
     booking_window =
-      Flow.Window.fixed(15, :second, fn _booking -> :os.system_time(:milli_seconds) end)
+      Flow.Window.fixed(1, :minute, fn _booking -> :os.system_time(:milli_seconds) end)
 
     # todo: add date field to car position update
-    car_window = Flow.Window.fixed(15, :second, fn _car -> :os.system_time(:milli_seconds) end)
+    car_window = Flow.Window.fixed(1, :minute, fn _car -> :os.system_time(:milli_seconds) end)
 
     batch_of_bookings =
       bookings_stream
       # time window every minute?
       |> Flow.from_enumerable()
-      |> Flow.partition(window: booking_window, stages: 1, max_demand: 1)
+      |> Flow.partition(window: booking_window, stages: 1, max_demand: 5)
       |> Flow.reduce(fn -> [] end, fn e, acc -> [e | acc] end)
       |> Flow.departition(fn -> [] end, &(&1 ++ &2), &Enum.sort/1)
 
@@ -52,7 +52,7 @@ defmodule Engine.App do
       cars_stream
       # sliding window of ten minutes?
       |> Flow.from_enumerable()
-      |> Flow.partition(window: car_window, stages: 1, max_demand: 1)
+      |> Flow.partition(window: car_window, stages: 1, max_demand: 5)
       |> Flow.reduce(fn -> [] end, fn e, acc -> [e | acc] end)
       |> Flow.departition(fn -> [] end, &(&1 ++ &2), &Enum.sort/1)
 

--- a/packages/engine-elixir/lib/engine.ex
+++ b/packages/engine-elixir/lib/engine.ex
@@ -16,7 +16,7 @@ end
 defmodule Engine.App do
   use Task
 
-  @chunk_size 1
+  @chunk_size 2
 
   def start_link(_arg) do
     Task.start_link(__MODULE__, :start, _arg)
@@ -27,24 +27,37 @@ defmodule Engine.App do
     %{booking: booking, car: car, score: detour.diff}
   end
 
-
-
   def start() do
     cars_stream = Routes.init()
     bookings_stream = BookingRequests.init()
 
+    # todo: add date field to the booking
+    booking_window = Flow.Window.fixed(1, :minute, fn _booking -> NaiveDateTime.utc_now() end)
+    # todo: add date field to car position update
+    car_window = Flow.Window.fixed(1, :minute, fn _car -> NaiveDateTime.utc_now() end)
+
     batch_of_bookings =
       bookings_stream
       # time window every minute?
-      |> Stream.chunk_every(@chunk_size)
+      |> Flow.from_enumerable()
+      |> Flow.partition(window: booking_window, stages: 1, max_demand: 5)
+
+    # |> Stream.chunk_every(@chunk_size)
 
     batch_of_cars =
       cars_stream
       # sliding window of ten minutes?
-      |> Stream.chunk_every(@chunk_size)
+      |> Flow.from_enumerable()
+      |> Flow.partition(window: car_window, stages: 1, max_demand: 5)
 
+    # |> Stream.chunk_every(@chunk_size)
 
-    Dispatch.find_and_offer_cars(batch_of_bookings, batch_of_cars, &Car.offer/2, &Booking.assign/2)
+    Dispatch.find_and_offer_cars(
+      batch_of_bookings,
+      batch_of_cars,
+      &Car.offer/2,
+      &Booking.assign/2
+    )
     |> Stream.run()
   end
 end

--- a/packages/engine-elixir/lib/engine.ex
+++ b/packages/engine-elixir/lib/engine.ex
@@ -17,6 +17,7 @@ defmodule Engine.App do
   use Task
 
   @chunk_size 2
+  @window_time 60000
 
   def start_link(_arg) do
     Task.start_link(__MODULE__, :start, _arg)
@@ -28,52 +29,69 @@ defmodule Engine.App do
   end
 
   def start() do
-    cars_stream = Routes.init()
-    bookings_stream = BookingRequests.init()
+    cars_agent = Routes.init()
+    bookings_agent = BookingRequests.init()
 
     # todo: add date field to the booking
-    booking_window =
-      Flow.Window.fixed(20, :second, fn _booking -> :os.system_time(:milli_seconds) end)
+    # booking_window =
+    #   Flow.Window.fixed(20, :second, fn _booking -> :os.system_time(:milli_seconds) end)
 
     # todo: add date field to car position update
-    car_window = Flow.Window.fixed(20, :second, fn _car -> :os.system_time(:milli_seconds) end)
+    # car_window = Flow.Window.fixed(20, :second, fn _car -> :os.system_time(:milli_seconds) end)
 
-    batch_of_bookings =
-      bookings_stream
-      # time window every minute?
-      |> Flow.from_enumerable()
-      |> Flow.partition(window: booking_window, stages: 1, max_demand: 5)
-      |> Flow.reduce(fn -> [] end, fn e, acc -> [e | acc] end)
-      |> Flow.departition(fn -> [] end, &(&1 ++ &2), &Enum.sort/1)
-      |> Flow.map(fn items ->
-        IO.puts("Process a batch of #{length(items)} bookings")
-        items
-      end)
+    # batch_of_bookings =
+    #   bookings_stream
+    #   # time window every minute?
+    #   |> Flow.from_enumerable()
+    #   |> Flow.partition(window: booking_window, stages: 1, max_demand: 5)
+    #   |> Flow.reduce(fn -> [] end, fn e, acc -> [e | acc] end)
+    #   |> Flow.departition(fn -> [] end, &(&1 ++ &2), &Enum.sort/1)
+    #   |> Flow.map(fn items ->
+    #     IO.puts("Process a batch of #{length(items)} bookings")
+    #     items
+    #   end)
 
     # |> Stream.chunk_every(@chunk_size)
 
-    batch_of_cars =
-      cars_stream
-      # sliding window of ten minutes?
-      |> Flow.from_enumerable()
-      |> Flow.partition(window: car_window, stages: 1, max_demand: 5)
-      |> Flow.reduce(fn -> [] end, fn e, acc -> [e | acc] end)
-      |> Flow.departition(fn -> [] end, &(&1 ++ &2), &Enum.sort/1)
-      |> Flow.map(fn items ->
-        IO.puts("Process a batch of #{length(items)} cars")
-        items
-      end)
+    # batch_of_cars =
+    #   cars_stream
+    #   # sliding window of ten minutes?
+    #   |> Flow.from_enumerable()
+    #   |> Flow.partition(window: car_window, stages: 1, max_demand: 5)
+    #   |> Flow.reduce(fn -> [] end, fn e, acc -> [e | acc] end)
+    #   |> Flow.departition(fn -> [] end, &(&1 ++ &2), &Enum.sort/1)
+    #   |> Flow.map(fn items ->
+    #     IO.puts("Process a batch of #{length(items)} cars")
+    #     items
+    #   end)
 
     # |> Stream.chunk_every(@chunk_size)
 
     IO.puts("Starting dispatch")
 
-    Dispatch.find_and_offer_cars(
-      batch_of_bookings,
-      batch_of_cars,
-      &Car.offer/2,
-      &Booking.assign/2
-    )
+    # Dispatch.find_and_offer_cars(
+    #   batch_of_bookings,
+    #   batch_of_cars,
+    #   &Car.offer/2,
+    #   &Booking.assign/2
+    # )
+    # |> Stream.run()
+
+    Stream.interval(@window_time)
+    |> Stream.map(fn _ ->
+      [
+        [Agent.get_and_update(bookings_agent, fn bookings -> {bookings, []} end)],
+        [Agent.get_and_update(cars_agent, fn cars -> {cars, []} end)]
+      ]
+    end)
+    |> Stream.map(fn [batch_of_bookings, batch_of_cars] ->
+      Dispatch.find_and_offer_cars(
+        batch_of_bookings,
+        batch_of_cars,
+        &Car.offer/2,
+        &Booking.assign/2
+      )
+    end)
     |> Stream.run()
   end
 end

--- a/packages/engine-elixir/lib/mq.ex
+++ b/packages/engine-elixir/lib/mq.ex
@@ -31,6 +31,9 @@ defmodule MQ do
     receive do
       {:basic_deliver, payload, %{correlation_id: ^correlation_id}} ->
         payload
+    after
+      20000 ->
+        "false"
     end
   end
 

--- a/packages/engine-elixir/lib/routes.ex
+++ b/packages/engine-elixir/lib/routes.ex
@@ -22,7 +22,9 @@ defmodule Routes do
       AMQP.Queue.bind(channel, queue, exchange)
 
       AMQP.Queue.subscribe(channel, queue, fn car, _meta ->
-        send(parent, {:msg, car: Car.make(decode(car))})
+        car_decoded = decode(car)
+        IO.puts("Got location for car #{car_decoded.id}")
+        send(parent, {:msg, car: Car.make(car_decoded)})
       end)
     end)
   end

--- a/packages/engine-elixir/test/dispatch_test.exs
+++ b/packages/engine-elixir/test/dispatch_test.exs
@@ -397,6 +397,5 @@ defmodule DispatchTest do
       |> Enum.to_list()
 
     assert length(candidates) > 0
-    assert length(candidates) == length(batch_of_bookings)
   end
 end

--- a/packages/engine-elixir/test/dispatch_test.exs
+++ b/packages/engine-elixir/test/dispatch_test.exs
@@ -196,7 +196,6 @@ defmodule DispatchTest do
              "(volvo) iteamToRadu -> (tesla) iteamToChristian -> (volvo) iteamToKungstradgarden -> (tesla) iteamToRalis -> (volvo) iteamToRadu"
   end
 
-
   test "two optimal routes with two cars" do
     cars = [@tesla, @volvo]
 
@@ -274,9 +273,126 @@ defmodule DispatchTest do
     assert length(batch_of_cars) == chunk_size
 
     candidates =
-      Dispatch.find_and_offer_cars([batch_of_bookings], [batch_of_cars], car_offer, assign_booking)
+      Dispatch.find_and_offer_cars(
+        [batch_of_bookings],
+        [batch_of_cars],
+        car_offer,
+        assign_booking
+      )
       |> Enum.to_list()
 
     assert length(candidates) == chunk_size
+  end
+
+  test "get batch of cars and bookings using fixed windows" do
+    hub = %{lat: 61.820701, lon: 16.057731}
+    chunk_size = 2
+
+    bookings =
+      Stream.iterate(0, &(&1 + 1))
+      |> Stream.map(fn id ->
+        Process.sleep(1100)
+        %{id: id, type: "booking"}
+      end)
+
+    cars =
+      Stream.iterate(0, &(&1 + 1))
+      |> Stream.map(fn id ->
+        Process.sleep(1500)
+        %{id: id, type: "car"}
+      end)
+
+    booking_window =
+      Flow.Window.fixed(5, :second, fn _booking -> :os.system_time(:milli_seconds) end)
+
+    car_window = Flow.Window.fixed(5, :second, fn _car -> :os.system_time(:milli_seconds) end)
+
+    batch_of_bookings =
+      bookings
+      |> Flow.from_enumerable()
+      |> Flow.partition(window: booking_window, stages: 1, max_demand: 1)
+      |> Flow.reduce(fn -> [] end, fn e, acc -> [e | acc] end)
+      |> Flow.departition(fn -> [] end, &(&1 ++ &2), &Enum.sort/1)
+      |> Enum.take(1)
+      |> List.first()
+      |> IO.inspect(label: "is booking")
+
+    batch_of_cars =
+      cars
+      |> Flow.from_enumerable()
+      |> Flow.partition(window: car_window, stages: 1, max_demand: 1)
+      |> Flow.reduce(fn -> [] end, fn e, acc -> [e | acc] end)
+      |> Flow.departition(fn -> [] end, &(&1 ++ &2), &Enum.sort/1)
+      |> Enum.take(1)
+      |> List.first()
+      |> IO.inspect(label: "is cars")
+
+    assign_booking = fn _booking, _car -> true end
+
+    assert length(batch_of_bookings) == 4
+    assert length(batch_of_cars) == 3
+  end
+
+  @tag :flow
+  test "offers bookings to cars using fixed windows" do
+    hub = %{lat: 61.820701, lon: 16.057731}
+
+    bookings =
+      Stream.iterate(0, &(&1 + 1)) |> Stream.map(&Booking.make(&1, hub, Address.random(hub)))
+
+    cars = Stream.iterate(0, &(&1 + 1)) |> Stream.map(&Car.make(&1, hub, false))
+
+    booking_window =
+      Flow.Window.fixed(5, :second, fn _booking -> :os.system_time(:milli_seconds) end)
+
+    car_window = Flow.Window.fixed(5, :second, fn _car -> :os.system_time(:milli_seconds) end)
+
+    batch_of_bookings =
+      bookings
+      |> Flow.from_enumerable()
+      |> Flow.partition(window: booking_window, stages: 1, max_demand: 1)
+      |> Flow.reduce(fn -> [] end, fn e, acc -> [e | acc] end)
+      |> Flow.departition(fn -> [] end, &(&1 ++ &2), &Enum.sort/1)
+      |> Enum.take(1)
+      |> List.first()
+      |> IO.inspect(label: "is bookings")
+
+    batch_of_cars =
+      cars
+      |> Flow.from_enumerable()
+      |> Flow.partition(window: car_window, stages: 1, max_demand: 1)
+      |> Flow.reduce(fn -> [] end, fn e, acc -> [e | acc] end)
+      |> Flow.departition(fn -> [] end, &(&1 ++ &2), &Enum.sort/1)
+      |> Enum.take(1)
+      |> List.first()
+      |> IO.inspect(label: "is cars")
+
+    accept = fn car, booking ->
+      IO.puts("Offer booking #{booking.id} to car #{car.id}")
+      true
+    end
+
+    delay_and_accept = fn delay ->
+      Process.sleep(delay)
+      accept
+    end
+
+    car_offer = fn car, booking ->
+      Car.offer(car, booking, delay_and_accept.(10))
+    end
+
+    assign_booking = fn _booking, _car -> true end
+
+    candidates =
+      Dispatch.find_and_offer_cars(
+        batch_of_bookings,
+        batch_of_cars,
+        car_offer,
+        assign_booking
+      )
+      |> Enum.take(2)
+      |> List.first()
+
+    assert length(candidates) == 2
   end
 end

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -16,6 +16,10 @@ build:
       context: packages/driver-interface
     - image: iteam1337/pm-engine
       context: packages/engine-elixir
+      sync:
+        infer:
+          - "**/*.ex"
+          - "**/*.exs"
 deploy:
   kubectl:
     manifests:


### PR DESCRIPTION
- change Routes and BookingRequests from Stream to Agent
- Routes and BookingRequests subscribe to rabbitmq and update the data in the agent on new messages
- Engine sets an interval of 60 seconds where it pulls the data from the agents and clears it so that it won't process it again on next run and then sends to dispatch
- switched everything from Stream to Enum in Dispatch since we don't have Streams anymore
- Reverted back to the Flow piece of code in Dispatch for offering the bookings to drivers in parallel (hopefully it works)
- added a timeout of 20 seconds on the rpc call to prevent people not accepting the offers from blocking the application