### PR TITLE
fix: creating both historical and telegram bookings crashes the system

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,50 @@ services:
       - 15672:15672
     networks:
       - predictivemovement
-
+  admin-ui:
+    build:
+      context: ./packages/engine-ui
+      args:
+        - REACT_APP_MAPBOX_ACCESS_TOKEN=${REACT_APP_MAPBOX_ACCESS_TOKEN}
+        - REACT_APP_ENGINE_SERVER=http://localhost:4000
+    ports:
+      - 3000:80
+    networks:
+      - predictivemovement
+  admin-server:
+    build: ./packages/engine-server
+    environment:
+      - AMQP_HOST=amqp://rabbitmq
+    ports:
+      - 4000:4000
+    networks:
+      - predictivemovement
+  predictivemovement-route-optimization-jsprit:
+    build: ./packages/route-optimization-jsprit
+    container_name: "predictivemovement_route-optimization-jsprit"
+    environment:
+      - RABBITMQ_HOST=rabbitmq
+      - RABBITMQ_PORT=5672
+    networks:
+      - predictivemovement
+  vehicle-offer-router:
+    build: ./packages/vehicle-offer
+    environment:
+      - AMQP_HOST=amqp://rabbitmq
+    networks:
+      - predictivemovement
+  auto-accept-offer:
+    build: ./packages/auto-accept-offer
+    environment:
+      - AMQP_HOST=amqp://rabbitmq
+    networks:
+      - predictivemovement
+  booking-dispatcher:
+    build: ./packages/booking-dispatcher
+    environment:
+      - AMQP_HOST=amqp://rabbitmq
+    networks:
+      - predictivemovement
 networks:
   predictivemovement:
     driver: bridge

--- a/packages/booking-dispatcher/Dockerfile
+++ b/packages/booking-dispatcher/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:slim
 WORKDIR /app
+COPY data .
 COPY ./package.json .
 COPY ./package-lock.json .
 RUN npm ci

--- a/packages/booking-dispatcher/lib/index.js
+++ b/packages/booking-dispatcher/lib/index.js
@@ -14,14 +14,14 @@ const inArea = (code) => {
 }
 
 const jsonPackages = readXlsx(
-  `${process.cwd()}/data/${process.env.file}`,
+  `${process.cwd()}/data/paketdata.xlsx`,
   'Paket 2019 Till Ljusdals kommun'
 ).filter(
   ({ FromCityCode, ToCityCode }) => inArea(FromCityCode) && inArea(ToCityCode)
 )
 
 const jsonAddresses = readXlsx(
-  `${process.cwd()}/data/${process.env.addresses}`,
+  `${process.cwd()}/data/fastigheter.xlsx`,
   'Fastigheter 2019'
 ).map((row) => {
   const [lat, lon] = swerefConverter(
@@ -49,11 +49,6 @@ const getRandomAddress = (postalNumber) => {
 }
 
 const bookingDispatcher = async (total) => {
-  if (!process.env.file) {
-    console.error('No file specified')
-    return
-  }
-
   jsonPackages
     .map((package) => {
       return {

--- a/packages/booking-interface/consumers/bookingAssignments.js
+++ b/packages/booking-interface/consumers/bookingAssignments.js
@@ -21,22 +21,25 @@ const bookingAssignments = () => {
         .then(() => ch.bindQueue(BOOKING_ASSIGNED, BOOKINGS, 'assigned'))
         .then(
           () =>
-            new Promise((resolve) => {
-              ch.consume(BOOKING_ASSIGNED, (msg) => {
-                const message = JSON.parse(msg.content.toString())
-                ch.ack(msg)
-                resolve(message)
-              })
+            ch.consume(BOOKING_ASSIGNED, (msg) => {
+              const message = JSON.parse(msg.content.toString())
+              console.log('incoming booking assignment')
+              ch.ack(msg)
+              notifyBooker(message)
             })
         )
-        .then((booking) =>
-          messaging.onBookingConfirmed(
-            booking.metadata.telegram.senderId,
-            booking.assigned_to.id,
-            booking.events
-          )
-        )
     )
+}
+
+function notifyBooker (booking) {
+  if (booking.metadata.telegram) {
+    console.log('Telegram BOOKING ASSIGNED, notifying booker', booking)
+    messaging.onBookingConfirmed(
+      booking.metadata.telegram.senderId,
+      booking.assigned_to.id,
+      booking.events
+    )
+  }
 }
 
 module.exports = { bookingAssignments }

--- a/packages/booking-interface/consumers/deliveryConfirmed.js
+++ b/packages/booking-interface/consumers/deliveryConfirmed.js
@@ -23,23 +23,19 @@ const deliveryConfirmed = () =>
         )
         .then(
           () =>
-            new Promise((resolve) => {
               ch.consume(queues.DELIVERY_CONFIRMED, (msg) => {
                 const message = JSON.parse(msg.content.toString())
                 ch.ack(msg)
-                resolve(message)
+                notifyBooker(message)
               })
-            })
-        )
-        .then(
-          ({
-            metadata: {
-              telegram: { senderId },
-            },
-          }) => {
-            return messaging.onDeliveryConfirmed(senderId)
-          }
         )
     )
+
+function notifyBooker(booking) {
+  if (booking.metadata.telegram) {
+    console.log('Telegram DELIVERY CONFIRMED, notifying booker')
+    return messaging.onDeliveryConfirmed(booking.metadata.telegram.senderId)
+  }
+}
 
 module.exports = { deliveryConfirmed }

--- a/packages/booking-interface/consumers/pickupConfirmed.js
+++ b/packages/booking-interface/consumers/pickupConfirmed.js
@@ -24,17 +24,19 @@ const pickupConfirmed = () =>
         )
         .then(
           () =>
-            new Promise((resolve) => {
               ch.consume(queues.PICKUP_CONFIRMED, (msg) => {
                 const message = JSON.parse(msg.content.toString())
                 ch.ack(msg)
-                resolve(message)
+                notifyBooker(message)
               })
-            })
-        )
-        .then(({ metadata: { telegram: { senderId } } }) =>
-          messaging.onPickupConfirmed(senderId)
         )
     )
+
+function notifyBooker(booking) {
+  console.log('PICKUP_CONFIRMED, notifing booker', booking)
+  if (booking.metadata.telegram) {
+    messaging.onPickupConfirmed(booking.metadata.telegram.senderId)
+  }
+}
 
 module.exports = { pickupConfirmed }

--- a/packages/engine-server/lib/routes.js
+++ b/packages/engine-server/lib/routes.js
@@ -61,6 +61,7 @@ function register(io) {
     })
 
     socket.on('dispatch-offers', () => {
+      console.log('received message to dispatch offers, from UI')
       dispatchOffers()
     })
 

--- a/packages/engine-ui/src/App.js
+++ b/packages/engine-ui/src/App.js
@@ -32,6 +32,7 @@ const App = () => {
   }
 
   const dispatchOffers = () => {
+    console.log('user pressed the dispatch button')
     socket.emit('dispatch-offers')
   }
 

--- a/packages/engine-ui/src/components/AddVehicle.js
+++ b/packages/engine-ui/src/components/AddVehicle.js
@@ -29,7 +29,12 @@ const AddVehicle = ({ addVehicle, currentPosition }) => {
 
   const create = (event) => {
     event.preventDefault()
-    const position = formState
+    let position
+    if (formState === '') {
+      console.log('creating vehicle in middle of ljusdal')
+      formState = '61.8294925,16.0565493'
+    }
+    position = formState
       .split(',')
       .map(parseFloat)
       .filter((x) => !!x)

--- a/packages/engine-ui/src/index.tsx
+++ b/packages/engine-ui/src/index.tsx
@@ -4,7 +4,7 @@ import './index.css'
 import App from './App.js'
 import * as serviceWorker from './serviceWorker'
 import { SocketIOProvider } from 'use-socketio'
-
+console.log('starting UI against server', process.env.REACT_APP_ENGINE_SERVER)
 ReactDOM.render(
   <SocketIOProvider
     url={process.env.REACT_APP_ENGINE_SERVER || 'http://localhost:4000'}

--- a/packages/engine/lib/dispatcher.ex
+++ b/packages/engine/lib/dispatcher.ex
@@ -3,8 +3,11 @@ defmodule Dispatcher do
     IO.puts("Dispatching!")
 
     PlanStore.get_plan()
+    |> (fn vehicles ->
+          IO.inspect(length(vehicles), label: "amount of vehicles to be offered")
+          vehicles
+        end).()
     |> Enum.map(&Vehicle.offer/1)
-    |> IO.inspect(label: "result from offer")
 
     # |> Enum.each(....Engine.MatchProducer.remove_bookings)
   end

--- a/packages/engine/lib/vehicle.ex
+++ b/packages/engine/lib/vehicle.ex
@@ -41,7 +41,7 @@ defmodule Vehicle do
           activities: activities,
           booking_ids: booking_ids
         },
-        "pickup_offers"
+        Application.fetch_env!(:engine, :pickup_offers_queue)
       )
       |> Poison.decode()
       |> IO.inspect(label: "the driver answered")

--- a/packages/vehicle-offer/index.js
+++ b/packages/vehicle-offer/index.js
@@ -1,4 +1,6 @@
 const { open, queues } = require('./amqp')
+console.log('Sending telegram offers to ', queues.TELEGRAM_OFFERS)
+console.log('Sending generated offers to ', queues.AUTO_ACCEPT_OFFERS)
 console.log(Object.values(queues))
 open
   .then((conn) => conn.createChannel())
@@ -13,11 +15,12 @@ open
       .then(() =>
         ch.consume(queues.PICKUP_OFFERS, async (message) => {
           const { vehicle } = JSON.parse(message.content.toString())
-
           const fromTelegram = vehicle.metadata && vehicle.metadata.telegram
           const queue = fromTelegram
             ? queues.TELEGRAM_OFFERS
             : queues.AUTO_ACCEPT_OFFERS
+          console.log("Received pickup offer to:", vehicle)
+          console.log("To queue:", queue)
 
           ch.sendToQueue(queue, message.content, message.properties)
 


### PR DESCRIPTION
This makes sure that the interface doesn't crash if it receives a message without a senderId (aka when the booking is autogenerated)

Also removes the need of .env variable in booking dispatcher. Just place the files in /data folder