### PR TITLE
fix: use same booking for genserver and mq publish

### DIFF
--- a/packages/elixir_umbrella/elixir_apps/engine/lib/booking.ex
+++ b/packages/elixir_umbrella/elixir_apps/engine/lib/booking.ex
@@ -16,7 +16,6 @@ defmodule Booking do
       size: size
     }
 
-    IO.inspect(booking, label: "this is the booking")
 
     GenServer.start_link(
       __MODULE__,

--- a/packages/elixir_umbrella/elixir_apps/engine/lib/booking.ex
+++ b/packages/elixir_umbrella/elixir_apps/engine/lib/booking.ex
@@ -9,22 +9,18 @@ defmodule Booking do
     booking = %Booking{
       id: id,
       pickup: pickup,
+      external_id: external_id,
       delivery: delivery,
       metadata: metadata,
-      events: []
+      events: [],
+      size: size
     }
+
+    IO.inspect(booking, label: "this is the booking")
 
     GenServer.start_link(
       __MODULE__,
-      %Booking{
-        id: id,
-        external_id: external_id,
-        pickup: pickup,
-        delivery: delivery,
-        metadata: metadata,
-        events: [],
-        size: size
-      },
+      booking,
       name: via_tuple(id)
     )
 


### PR DESCRIPTION
We were defining one booking for mq.publish, and different one for the genserver.