### PR TITLE
chore: rename pickup instructions queue

### DIFF
--- a/packages/driver-interface/adapters/amqp.js
+++ b/packages/driver-interface/adapters/amqp.js
@@ -11,7 +11,7 @@ const exchanges = {
 
 const queues = {
   OFFER_BOOKING_TO_TELEGRAM_VEHICLE: 'offer_bookings_to_telegram_vehicles',
-  PICKUP_INSTRUCTIONS: 'pickup_instructions',
+  SEND_PICKUP_INSTRUCTIONS: 'send_pickup_instructions_to_driver',
   SEND_PLAN_TO_VEHICLE: 'send_plan_to_vehicle',
 }
 

--- a/packages/driver-interface/consumers/pickupInstructions.js
+++ b/packages/driver-interface/consumers/pickupInstructions.js
@@ -13,7 +13,7 @@ const pickupInstructions = () => {
     .then((conn) => conn.createChannel())
     .then((ch) =>
       ch
-        .assertQueue(PICKUP_INSTRUCTIONS, {
+        .assertQueue(SEND_PICKUP_INSTRUCTIONS, {
           durable: false,
         })
         .then(() =>
@@ -21,9 +21,9 @@ const pickupInstructions = () => {
             durable: false,
           })
         )
-        .then(() => ch.bindQueue(PICKUP_INSTRUCTIONS, OUTGOING_BOOKING_UPDATES, 'assigned'))
+        .then(() => ch.bindQueue(SEND_PICKUP_INSTRUCTIONS, OUTGOING_BOOKING_UPDATES, 'assigned'))
         .then(() =>
-          ch.consume(PICKUP_INSTRUCTIONS, (msg) => {
+          ch.consume(SEND_PICKUP_INSTRUCTIONS, (msg) => {
             const booking = JSON.parse(msg.content.toString())
             const fromTelegram =
               booking.assigned_to.metadata &&


### PR DESCRIPTION
To be consistent with the rest of the queues this PR renames pickup_instructions queue to send_pickup_instructions_to_driver.