### PR TITLE
chore: add route to booking in engine

### DIFF
--- a/packages/elixir_umbrella/elixir_apps/engine/lib/booking.ex
+++ b/packages/elixir_umbrella/elixir_apps/engine/lib/booking.ex
@@ -74,7 +74,6 @@ defmodule Booking do
       |> Map.put(:events, [%{timestamp: DateTime.utc_now(), type: :assigned} | state.events])
 
     updated_state
-    |> IO.inspect(label: "publishing assigned")
     |> MQ.publish(
       Application.fetch_env!(:engine, :outgoing_booking_exchange),
       "assigned"

--- a/packages/elixir_umbrella/elixir_apps/engine/lib/booking.ex
+++ b/packages/elixir_umbrella/elixir_apps/engine/lib/booking.ex
@@ -1,7 +1,7 @@
 defmodule Booking do
   use GenServer
   require Logger
-  @outgoing_booking_exchange Application.fetch_env!(:engine, :outgoing_booking_exchange)
+  @outgoing_booking_exchange Application.compile_env!(:engine, :outgoing_booking_exchange)
 
   defstruct [
     :id,
@@ -36,7 +36,8 @@ defmodule Booking do
     )
 
     MQ.publish(
-      Application.fetch_env!(:engine, :outgoing_booking_exchange),
+      booking,
+      @outgoing_booking_exchange,
       "new"
     )
 


### PR DESCRIPTION
This adds route to a booking when creating it, so that listeners can plot the route on a map.