### PR TITLE
fix: handle status upated when booking id not in engine

### DIFF
--- a/packages/driver-interface/botRoutes.js
+++ b/packages/driver-interface/botRoutes.js
@@ -10,6 +10,7 @@ const {
 function onPickup(ctx) {
   const telegramId = ctx.update.callback_query.from.id
   const vehicleId = ctx.metadata.getVehicleIdFromTelegramId(telegramId)
+  if (!vehicleId) return messaging.onNoInstructionsForVehicle(ctx)
   const callbackPayload = JSON.parse(ctx.update.callback_query.data)
 
   open
@@ -31,11 +32,12 @@ function onPickup(ctx) {
   return botServices.handlePickupInstruction(vehicleId, telegramId)
 }
 
-function onDelivered(msg) {
-  const telegramId = msg.update.callback_query.from.id
-  const vehicleId = msg.metadata.getVehicleIdFromTelegramId(telegramId)
+function onDelivered(ctx) {
+  const telegramId = ctx.update.callback_query.from.id
+  const vehicleId = ctx.metadata.getVehicleIdFromTelegramId(telegramId)
+  if (!vehicleId) return messaging.onNoInstructionsForVehicle(ctx)
 
-  const callbackPayload = JSON.parse(msg.update.callback_query.data)
+  const callbackPayload = JSON.parse(ctx.update.callback_query.data)
   open
     .then((conn) => conn.createChannel())
     .then((ch) => {

--- a/packages/driver-interface/botRoutes.js
+++ b/packages/driver-interface/botRoutes.js
@@ -7,11 +7,10 @@ const {
   exchanges: { INCOMING_BOOKING_UPDATES },
 } = require('./adapters/amqp')
 
-function onPickup(msg) {
-  const telegramId = msg.update.callback_query.from.id
-  const vehicleId = msg.metadata.getVehicleIdFromTelegramId(telegramId)
-
-  const callbackPayload = JSON.parse(msg.update.callback_query.data)
+function onPickup(ctx) {
+  const telegramId = ctx.update.callback_query.from.id
+  const vehicleId = ctx.metadata.getVehicleIdFromTelegramId(telegramId)
+  const callbackPayload = JSON.parse(ctx.update.callback_query.data)
 
   open
     .then((conn) => conn.createChannel())
@@ -56,10 +55,10 @@ function onDelivered(msg) {
   return botServices.handlePickupInstruction(vehicleId, telegramId)
 }
 
-function onOffer(msg) {
-  const callbackPayload = JSON.parse(msg.update.callback_query.data)
+function onOffer(ctx) {
+  const callbackPayload = JSON.parse(ctx.update.callback_query.data)
   const { a: isAccepted, ...options } = callbackPayload
-  return messaging.onPickupOfferResponse(isAccepted, options, msg)
+  return messaging.onPickupOfferResponse(isAccepted, options, ctx)
 }
 
 const init = (bot) => {
@@ -108,16 +107,16 @@ const init = (bot) => {
   })
 
   /** Listen for user invoked button clicks. */
-  bot.on('callback_query', (msg) => {
-    const callbackPayload = JSON.parse(msg.update.callback_query.data)
+  bot.on('callback_query', (ctx) => {
+    const callbackPayload = JSON.parse(ctx.update.callback_query.data)
 
     switch (callbackPayload.e) {
       case 'picked_up':
-        return onPickup(msg)
+        return onPickup(ctx)
       case 'delivered':
-        return onDelivered(msg)
+        return onDelivered(ctx)
       case 'offer':
-        return onOffer(msg)
+        return onOffer(ctx)
       default:
         throw new Error(`unhandled event ${callbackPayload.e}`)
     }

--- a/packages/elixir_umbrella/elixir_apps/engine/lib/booking.ex
+++ b/packages/elixir_umbrella/elixir_apps/engine/lib/booking.ex
@@ -76,8 +76,14 @@ defmodule Booking do
 
   def assign(booking_id, vehicle), do: GenServer.call(via_tuple(booking_id), {:assign, vehicle})
 
-  def add_event(booking_id, status) when status in ["picked_up", "delivered"],
-    do: GenServer.call(via_tuple(booking_id), {:add_event, status})
+  def add_event(booking_id, status) when status in ["picked_up", "delivered"] do
+    try do
+      GenServer.call(via_tuple(booking_id), {:add_event, status})
+    catch
+      :exit, {:noproc, _} ->
+        {:error, "No process found with that id"}
+    end
+  end
 
   defp via_tuple(id) when is_integer(id), do: via_tuple(Integer.to_string(id))
 

--- a/packages/elixir_umbrella/elixir_apps/engine/lib/booking_updates_processor.ex
+++ b/packages/elixir_umbrella/elixir_apps/engine/lib/booking_updates_processor.ex
@@ -1,6 +1,6 @@
 defmodule Engine.BookingUpdatesProcessor do
   use Broadway
-
+  require Logger
   @incoming_booking_exchange Application.compile_env!(:engine, :incoming_booking_exchange)
   @picked_up_routing_key "picked_up"
   @delivered_routing_key "delivered"
@@ -32,11 +32,16 @@ defmodule Engine.BookingUpdatesProcessor do
   end
 
   def handle_message(_, %Broadway.Message{data: booking_update} = msg, _) do
-    %{id: id, status: status} =
-      booking_update
-      |> Poison.decode!(keys: :atoms)
+    with %{id: id, status: status} <- Poison.decode!(booking_update, keys: :atoms),
+         true <- Booking.add_event(id, status) do
+      Logger.debug("Booking with ID #{id} has been assigned status #{status}")
+    else
+      {:error, error_msg} ->
+        Logger.error("Could not set status: #{error_msg}")
 
-    Booking.add_event(id, status)
+      other_error ->
+        Logger.error("Could not set status: #{other_error}")
+    end
 
     msg
   end


### PR DESCRIPTION
This makes elixir ack booking updates, and print error message, if booking id not found.

Also doesn't send message if bot doesn't have vehicle in memory.