### PR TITLE
fix: issue when using same address for deliver/pickup

### DIFF
--- a/packages/elixir_umbrella/elixir_apps/engine/lib/plan.ex
+++ b/packages/elixir_umbrella/elixir_apps/engine/lib/plan.ex
@@ -27,7 +27,6 @@ defmodule Plan do
           [start_address, end_address]
         end)
       )
-      |> Enum.uniq()
       |> Osrm.get_time_between_coordinates()
       |> Map.delete(:code)
 


### PR DESCRIPTION
after changing from `position` on vehicle to `start_address` and `end_address` there was an issue in jsprit for vehicles that have the start_address and end_address the same so a `Enum.uniq` was used to filter duplicates.

this change created an issue for having the same address on multiple bookings so now removing the Enum.uniq the issue in jsprit seemed to have been fixed by other changes.