### PR TITLE
chore: remove rabbit cancel ok error

### DIFF
--- a/packages/elixir_umbrella/elixir_apps/engine/lib/amqp.ex
+++ b/packages/elixir_umbrella/elixir_apps/engine/lib/amqp.ex
@@ -14,8 +14,7 @@ defmodule MQ do
   def wait_for_messages(channel, correlation_id) do
     receive do
       {:basic_deliver, payload, %{correlation_id: ^correlation_id} = msg} ->
-        AMQP.Basic.ack(channel, Map.get(msg, :delivery_tag))
-        AMQP.Queue.delete(channel, Map.get(msg, :routing_key))
+        AMQP.Queue.unsubscribe(channel, Map.get(msg, :consumer_tag))
         payload
 
       _ ->
@@ -32,7 +31,8 @@ defmodule MQ do
       AMQP.Queue.declare(
         channel,
         "",
-        exclusive: true
+        exclusive: true,
+        auto_delete: true
       )
 
     AMQP.Basic.consume(channel, queue_name, nil, no_ack: false)

--- a/packages/elixir_umbrella/elixir_apps/engine/lib/vehicle.ex
+++ b/packages/elixir_umbrella/elixir_apps/engine/lib/vehicle.ex
@@ -65,6 +65,8 @@ defmodule Vehicle do
         proposed_state,
         current_state
       ) do
+    Logger.info("Driver #{current_state.id} accepted")
+
     proposed_state.booking_ids
     |> Enum.map(fn booking_id ->
       Booking.assign(booking_id, current_state)
@@ -79,9 +81,11 @@ defmodule Vehicle do
   end
 
   def handle_driver_response({:ok, false}, _, state) do
-    Logger.debug("Driver didnt want the booking :(")
+    Logger.info("Driver didnt want the booking :(")
     state
   end
+
+  def handle_info({:basic_cancel_ok, _}, state), do: {:noreply, state}
 
   defp generate_id,
     do: "pmv-" <> (Base62UUID.generate() |> String.downcase() |> String.slice(0, 8))


### PR DESCRIPTION
Found a error in the logs indicating that "cancel-ok" message was not handled. 

With this, we simply take the read the message and do nothing.