### PR TITLE
fix: use new seralizer to not crash on new atoms

### DIFF
--- a/packages/engine_umbrella/apps/engine/lib/json_serializer.ex
+++ b/packages/engine_umbrella/apps/engine/lib/json_serializer.ex
@@ -1,0 +1,29 @@
+defmodule Engine.JsonSerializer do
+  @moduledoc """
+  A serializer that uses the JSON format.
+  """
+
+  @behaviour EventStore.Serializer
+
+  @doc """
+  Serialize given term to JSON binary data.
+  """
+  def serialize(term) do
+    Jason.encode!(term)
+  end
+
+  @doc """
+  Deserialize given JSON binary data to the expected type.
+  """
+  def deserialize(binary, config) do
+    case Keyword.get(config, :type, nil) do
+      nil ->
+        Jason.decode!(binary)
+
+      type ->
+        type
+        |> String.to_atom()
+        |> struct(Jason.decode!(binary, keys: :atoms))
+    end
+  end
+end

--- a/packages/engine_umbrella/config/config.exs
+++ b/packages/engine_umbrella/config/config.exs
@@ -14,8 +14,9 @@ config :engine, :booking_processor_batch_size, 1
 config :engine, :booking_processor_batch_timeout, 1000
 
 config :engine, event_stores: [Engine.ES]
+
 config :engine, Engine.ES,
-  serializer: EventStore.JsonSerializer,
+  serializer: Engine.JsonSerializer,
   username: "postgres",
   password: "postgres",
   database: "eventstore",

--- a/packages/engine_umbrella/config/releases.exs
+++ b/packages/engine_umbrella/config/releases.exs
@@ -18,7 +18,7 @@ config :engine,
        )
 
 config :engine, Engine.ES,
-  serializer: EventStore.JsonSerializer,
+  serializer: Engine.JsonSerializer,
   username: System.get_env("POSTGRES_USER"),
   password: System.get_env("POSTGRES_PASSWORD"),
   database: System.get_env("POSTGRES_DB"),


### PR DESCRIPTION
Replaced https://hexdocs.pm/eventstore/event-serialization.html#json-serialization-using-jason
with a custom serializer that doesn't use "to_existing_atom"