### PR TITLE
chore: migrate eventstore on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,10 @@ Start dependencies
 
     docker-compose up -d
 
-create event_store database
-    
-    cd packages/engine_umbrella/
-    mix do event_store.create, event_store.init
+run event_store migrations and start the engine
 
-run the engine
-    
-    iex -S mix
+    cd packages/engine_umbrella/
+    mix dev
 
 **Design mockup:** [Figma](https://www.figma.com/file/DdBjpoKd0T9OkWmhlpd48Nfa/Predictive-Movement)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,11 @@ services:
   postgres:
     image: postgres
     environment:
+      - PGDATA=/pgtmpfs
       - POSTGRES_PASSWORD=postgres
     ports:
       - 5432:5432
+    tmpfs: /pgtmpfs
     networks:
       - predictivemovement
   admin-ui:

--- a/packages/engine_umbrella/mix.exs
+++ b/packages/engine_umbrella/mix.exs
@@ -3,6 +3,7 @@ defmodule ElixirUmbrella.MixProject do
 
   def project do
     [
+      aliases: aliases(),
       apps_path: "apps",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -17,6 +18,12 @@ defmodule ElixirUmbrella.MixProject do
       ]
     ]
   end
+
+  def aliases do
+    [dev: ["event_store.create", "event_store.init", &run_app_in_shell/1]]
+  end
+
+  def run_app_in_shell(_), do: Mix.shell().cmd("iex -S mix")
 
   def application do
     [extra_applications: [:logger, :gproc]]


### PR DESCRIPTION
This PR adds an alias for migration & running the engine app.
It also removes the persistance of postgres in docker-compose, meaning if you restart your local postgres, the data will be erased.