### PR TITLE
 feat: 🎸 add excluded booking ids in the plan

### DIFF
--- a/packages/engine_umbrella/apps/engine/lib/processors/booking_processor.ex
+++ b/packages/engine_umbrella/apps/engine/lib/processors/booking_processor.ex
@@ -31,10 +31,14 @@ defmodule Engine.BookingProcessor do
     status =
       case failure.status_msg do
         "Time of time window constraint is in the past!" -> "TIME_CONSTRAINTS_EXPIRED"
-        _ -> failure.status_msg
+        _ -> handle_booking_failure(%{id: id})
       end
 
     %{id: id, status: status}
+  end
+
+  defp handle_booking_failure(%{id: id}) do
+    %{id: id, status: "CONSTRAINTS_FAILURE"}
   end
 
   def calculate_plan(vehicle_ids, booking_ids)

--- a/packages/engine_umbrella/apps/engine/lib/processors/booking_processor.ex
+++ b/packages/engine_umbrella/apps/engine/lib/processors/booking_processor.ex
@@ -32,7 +32,8 @@ defmodule Engine.BookingProcessor do
       do: IO.puts("No vehicles/bookings to calculate plan for")
 
   def calculate_plan(vehicle_ids, booking_ids) do
-    %{data: %{solution: %{routes: routes}}} = @plan.find_optimal_routes(vehicle_ids, booking_ids)
+    %{data: %{solution: %{routes: routes, excluded: excluded}}} =
+      @plan.find_optimal_routes(vehicle_ids, booking_ids)
 
     vehicles =
       routes
@@ -54,7 +55,11 @@ defmodule Engine.BookingProcessor do
         )
       end)
 
-    PlanStore.put_plan(%{vehicles: vehicles, booking_ids: booking_ids})
+    PlanStore.put_plan(%{
+      vehicles: vehicles,
+      booking_ids: booking_ids,
+      excluded_booking_ids: Enum.map(excluded, &Map.take(&1, [:id, :failure]))
+    })
   end
 
   def handle_message(

--- a/packages/engine_umbrella/apps/engine/test/booking_processor_test.exs
+++ b/packages/engine_umbrella/apps/engine/test/booking_processor_test.exs
@@ -248,40 +248,46 @@ defmodule BookingProcessorTest do
     expected_id =
       MessageGenerator.random_booking(%{
         id: "Gammelstad->LTU",
-        pickup: %{
-          lon: 22.015858,
-          lat: 65.641574,
-          time_windows: [
-            %{
-              earliest: ~U[1979-08-01 10:00:00.000Z],
-              latest: ~U[1979-08-01 11:00:00.000Z]
-            }
-          ]
-        },
-        delivery: %{
-          lon: 22.13488,
-          lat: 65.61582
-        },
         metadata: %{
           start: "Gammelstad (65.641574, 22.015858) -> LTU (65.61582, 22.13488)"
         }
       })
+      |> Map.put(:pickup, %{
+        lon: 22.015858,
+        lat: 65.641574,
+        time_windows: [
+          %{
+            earliest: ~U[1979-08-01 10:00:00.000Z],
+            latest: ~U[1979-08-01 11:00:00.000Z]
+          }
+        ]
+      })
+      |> Map.put(
+        :delivery,
+        %{
+          lon: 22.13488,
+          lat: 65.61582
+        }
+      )
       |> Booking.make()
 
     MessageGenerator.random_booking(%{
       id: "Gäddvik->LTU",
-      pickup: %{
-        lon: 22.051736,
-        lat: 65.581598
-      },
-      delivery: %{
-        lon: 22.13488,
-        lat: 65.61582
-      },
       metadata: %{
         start: "Gäddvik (65.581598, 22.051736) -> LTU (65.61582, 22.13488)"
       }
     })
+    |> Map.put(:pickup, %{
+      lon: 22.051736,
+      lat: 65.581598
+    })
+    |> Map.put(
+      :delivery,
+      %{
+        lon: 22.13488,
+        lat: 65.61582
+      }
+    )
     |> Booking.make()
 
     MessageGenerator.random_car(%{

--- a/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
@@ -155,8 +155,8 @@ defmodule MessageGenerator do
 
   defp do_add_vehicle_addresses(map, location) do
     map
-    |> Map.put_new(:start_address, Address.random(location))
-    |> Map.put_new(:end_address, Address.random(location))
+    |> Map.put(:start_address, Address.random(location))
+    |> Map.put(:end_address, Address.random(location))
   end
 
   def add_booking_addresses(map), do: do_add_booking_addresses(map, @ljusdal)
@@ -165,8 +165,8 @@ defmodule MessageGenerator do
 
   defp do_add_booking_addresses(map, location) do
     map
-    |> Map.put_new(:pickup, Address.random(location))
-    |> Map.put_new(:delivery, Address.random(location))
+    |> Map.put(:pickup, Address.random(location))
+    |> Map.put(:delivery, Address.random(location))
   end
 
   def add_random_id_and_time(map) do

--- a/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
@@ -155,8 +155,8 @@ defmodule MessageGenerator do
 
   defp do_add_vehicle_addresses(map, location) do
     map
-    |> Map.put(:start_address, Address.random(location))
-    |> Map.put(:end_address, Address.random(location))
+    |> Map.put_new(:start_address, Address.random(location))
+    |> Map.put_new(:end_address, Address.random(location))
   end
 
   def add_booking_addresses(map), do: do_add_booking_addresses(map, @ljusdal)
@@ -165,13 +165,13 @@ defmodule MessageGenerator do
 
   defp do_add_booking_addresses(map, location) do
     map
-    |> Map.put(:pickup, Address.random(location))
-    |> Map.put(:delivery, Address.random(location))
+    |> Map.put_new(:pickup, Address.random(location))
+    |> Map.put_new(:delivery, Address.random(location))
   end
 
   def add_random_id_and_time(map) do
     map
-    |> Map.put(:id, Enum.random(0..100_000))
+    |> Map.put_new(:id, Enum.random(0..100_000))
     |> Map.put(:bookingDate, DateTime.utc_now())
   end
 end


### PR DESCRIPTION
https://trello.com/c/ImTRBfy8/274-include-excluded-bookings-with-reason-in-the-plan-message

- use the `excluded` property from jsprit and include in the plan an `excluded_booking_ids` list of objects containing id and status
- temporary handle the failure from jsprit and convert it to a status (as this should be returned from jsprit in this format)  that the consumers can decode to a human readable message