### PR TITLE
feat: durable rabbitmq

### DIFF
--- a/k8s/rabbitmq.yaml
+++ b/k8s/rabbitmq.yaml
@@ -40,3 +40,53 @@ spec:
     name: rabbitmq
 status:
   loadBalancer: {}
+# apiVersion: apps/v1
+# kind: StatefulSet
+# metadata:
+#   name: rabbitmq
+#   namespace: predictivemovement
+# spec:
+#   replicas: 1
+#   selector:
+#     matchLabels:
+#       name: rabbitmq
+#   serviceName: rabbitmq
+#   template:
+#     metadata:
+#       labels:
+#         name: rabbitmq
+#     spec:
+#       containers:
+#         - image: rabbitmq:3-management
+#           name: rabbitmq
+#           ports:
+#             - containerPort: 5672
+#             - containerPort: 15672
+#           resources: {}
+#   volumeClaimTemplates:
+#     - metadata:
+#         name: rabbitmq-data
+#       spec:
+#         accessModes:
+#           - ReadWriteOnce
+#         resources:
+#           requests:
+#             storage: "10Gi"
+# ---
+# apiVersion: v1
+# kind: Service
+# metadata:
+#   name: rabbitmq
+#   namespace: predictivemovement
+# spec:
+#   ports:
+#     - name: "5672"
+#       port: 5672
+#       targetPort: 5672
+#     - name: "15672"
+#       port: 15672
+#       targetPort: 15672
+#   selector:
+#     name: rabbitmq
+# status:
+#   loadBalancer: {}

--- a/k8s/rabbitmq.yaml
+++ b/k8s/rabbitmq.yaml
@@ -1,13 +1,13 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: rabbitmq
-  namespace: predictivemovement
 spec:
   replicas: 1
   selector:
     matchLabels:
       name: rabbitmq
+  serviceName: rabbitmq
   template:
     metadata:
       labels:
@@ -19,15 +19,24 @@ spec:
           ports:
             - containerPort: 5672
             - containerPort: 15672
+          volumeMounts:
+            - name: rabbitmq-data
+              mountPath: "/var/lib/rabbitmq/mnesia"
           resources: {}
-      restartPolicy: Always
-status: {}
+  volumeClaimTemplates:
+    - metadata:
+        name: rabbitmq-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "5Gi"
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: rabbitmq
-  namespace: predictivemovement
 spec:
   ports:
     - name: "5672"
@@ -40,53 +49,3 @@ spec:
     name: rabbitmq
 status:
   loadBalancer: {}
-# apiVersion: apps/v1
-# kind: StatefulSet
-# metadata:
-#   name: rabbitmq
-#   namespace: predictivemovement
-# spec:
-#   replicas: 1
-#   selector:
-#     matchLabels:
-#       name: rabbitmq
-#   serviceName: rabbitmq
-#   template:
-#     metadata:
-#       labels:
-#         name: rabbitmq
-#     spec:
-#       containers:
-#         - image: rabbitmq:3-management
-#           name: rabbitmq
-#           ports:
-#             - containerPort: 5672
-#             - containerPort: 15672
-#           resources: {}
-#   volumeClaimTemplates:
-#     - metadata:
-#         name: rabbitmq-data
-#       spec:
-#         accessModes:
-#           - ReadWriteOnce
-#         resources:
-#           requests:
-#             storage: "10Gi"
-# ---
-# apiVersion: v1
-# kind: Service
-# metadata:
-#   name: rabbitmq
-#   namespace: predictivemovement
-# spec:
-#   ports:
-#     - name: "5672"
-#       port: 5672
-#       targetPort: 5672
-#     - name: "15672"
-#       port: 15672
-#       targetPort: 15672
-#   selector:
-#     name: rabbitmq
-# status:
-#   loadBalancer: {}

--- a/packages/booking-interface/consumers/bookingAssignments.js
+++ b/packages/booking-interface/consumers/bookingAssignments.js
@@ -11,26 +11,31 @@ const bookingAssignments = () => {
     .then((ch) =>
       ch
         .assertQueue(SET_BOOKING_ASSIGNED, {
-          durable: false,
+          durable: true,
         })
         .then(() =>
           ch.assertExchange(OUTGOING_BOOKING_UPDATES, 'topic', {
-            durable: false,
+            durable: true,
           })
         )
-        .then(() => ch.bindQueue(SET_BOOKING_ASSIGNED, OUTGOING_BOOKING_UPDATES, 'assigned'))
-        .then(
-          () =>
-            ch.consume(SET_BOOKING_ASSIGNED, (msg) => {
-              const message = JSON.parse(msg.content.toString())
-              ch.ack(msg)
-              notifyBooker(message)
-            })
+        .then(() =>
+          ch.bindQueue(
+            SET_BOOKING_ASSIGNED,
+            OUTGOING_BOOKING_UPDATES,
+            'assigned'
+          )
+        )
+        .then(() =>
+          ch.consume(SET_BOOKING_ASSIGNED, (msg) => {
+            const message = JSON.parse(msg.content.toString())
+            ch.ack(msg)
+            notifyBooker(message)
+          })
         )
     )
 }
 
-function notifyBooker (booking) {
+function notifyBooker(booking) {
   if (booking.metadata.telegram) {
     console.log('Telegram BOOKING ASSIGNED, notifying booker', booking)
     messaging.onBookingConfirmed(

--- a/packages/booking-interface/consumers/deliveryConfirmed.js
+++ b/packages/booking-interface/consumers/deliveryConfirmed.js
@@ -7,27 +7,26 @@ const deliveryConfirmed = () =>
     .then((ch) =>
       ch
         .assertQueue(queues.NOTIFY_DELIVERY, {
-          durable: false,
+          durable: true,
         })
         .then(() =>
           ch.assertExchange(exchanges.OUTGOING_BOOKING_UPDATES, 'topic', {
-            durable: false,
+            durable: true,
           })
         )
         .then(() =>
           ch.bindQueue(
             queues.NOTIFY_DELIVERY,
             exchanges.OUTGOING_BOOKING_UPDATES,
-            "delivered"
+            'delivered'
           )
         )
-        .then(
-          () =>
-              ch.consume(queues.NOTIFY_DELIVERY, (msg) => {
-                const message = JSON.parse(msg.content.toString())
-                ch.ack(msg)
-                notifyBooker(message)
-              })
+        .then(() =>
+          ch.consume(queues.NOTIFY_DELIVERY, (msg) => {
+            const message = JSON.parse(msg.content.toString())
+            ch.ack(msg)
+            notifyBooker(message)
+          })
         )
     )
 

--- a/packages/booking-interface/consumers/pickupConfirmed.js
+++ b/packages/booking-interface/consumers/pickupConfirmed.js
@@ -8,27 +8,26 @@ const pickupConfirmed = () =>
     .then((ch) =>
       ch
         .assertQueue(queues.NOTIFY_PICKUP, {
-          durable: false,
+          durable: true,
         })
         .then(() =>
           ch.assertExchange(exchanges.OUTGOING_BOOKING_UPDATES, 'topic', {
-            durable: false,
+            durable: true,
           })
         )
         .then(() =>
           ch.bindQueue(
             queues.NOTIFY_PICKUP,
             exchanges.OUTGOING_BOOKING_UPDATES,
-            "picked_up"
+            'picked_up'
           )
         )
-        .then(
-          () =>
-              ch.consume(queues.NOTIFY_PICKUP, (msg) => {
-                const message = JSON.parse(msg.content.toString())
-                notifyBooker(message)
-                ch.ack(msg)
-              })
+        .then(() =>
+          ch.consume(queues.NOTIFY_PICKUP, (msg) => {
+            const message = JSON.parse(msg.content.toString())
+            notifyBooker(message)
+            ch.ack(msg)
+          })
         )
     )
 

--- a/packages/booking-interface/services/amqp.js
+++ b/packages/booking-interface/services/amqp.js
@@ -6,13 +6,13 @@ const createBooking = (booking) => {
     .then((ch) =>
       ch
         .assertExchange(exchanges.INCOMING_BOOKING_UPDATES, 'topic', {
-          durable: false,
+          durable: true,
         })
         .then(() =>
           ch.publish(
             exchanges.INCOMING_BOOKING_UPDATES,
-            "registered",
-            Buffer.from(JSON.stringify({...booking, assigned_to: null}))
+            'registered',
+            Buffer.from(JSON.stringify({ ...booking, assigned_to: null }))
           )
         )
     )

--- a/packages/booking-interface/services/amqp.js
+++ b/packages/booking-interface/services/amqp.js
@@ -12,7 +12,10 @@ const createBooking = (booking) => {
           ch.publish(
             exchanges.INCOMING_BOOKING_UPDATES,
             'registered',
-            Buffer.from(JSON.stringify({ ...booking, assigned_to: null }))
+            Buffer.from(JSON.stringify({ ...booking, assigned_to: null })),
+            {
+              persistent: true,
+            }
           )
         )
     )

--- a/packages/driver-interface/src/botRoutes.ts
+++ b/packages/driver-interface/src/botRoutes.ts
@@ -11,7 +11,7 @@ const channel = open
   .then((conn) => conn.createChannel())
   .then((ch) => {
     ch.assertExchange(INCOMING_BOOKING_UPDATES, 'topic', {
-      durable: false,
+      durable: true,
     })
     return ch
   })

--- a/packages/driver-interface/src/botRoutes.ts
+++ b/packages/driver-interface/src/botRoutes.ts
@@ -34,7 +34,10 @@ function handleBookingEvent(telegramId, bookingIds, event) {
           openChannel.publish(
             INCOMING_BOOKING_UPDATES,
             event,
-            Buffer.from(JSON.stringify({ id, status: event }))
+            Buffer.from(JSON.stringify({ id, status: event })),
+            {
+              persistent: true,
+            }
           )
         )
       )

--- a/packages/driver-interface/src/consumers/pickupInstructions.ts
+++ b/packages/driver-interface/src/consumers/pickupInstructions.ts
@@ -12,11 +12,11 @@ const pickupInstructions = (): Promise<Replies.Consume> =>
     .then((ch) =>
       ch
         .assertQueue(ADD_BOOKING_INFO, {
-          durable: false,
+          durable: true,
         })
         .then(() =>
           ch.assertExchange(OUTGOING_BOOKING_UPDATES, 'topic', {
-            durable: false,
+            durable: true,
           })
         )
         .then(() =>

--- a/packages/driver-interface/src/consumers/vehiclePlan.ts
+++ b/packages/driver-interface/src/consumers/vehiclePlan.ts
@@ -12,11 +12,11 @@ const vehiclePlan = (): Promise<Replies.Consume> =>
     .then((ch) =>
       ch
         .assertQueue(ADD_INSTRUCTIONS_TO_VEHICLE, {
-          durable: false,
+          durable: true,
         })
         .then(() =>
           ch.assertExchange(OUTGOING_VEHICLE_UPDATES, 'topic', {
-            durable: false,
+            durable: true,
           })
         )
         .then(() =>

--- a/packages/driver-interface/src/services/amqp.ts
+++ b/packages/driver-interface/src/services/amqp.ts
@@ -10,7 +10,7 @@ export const updateLocation = (
     .then((conn) => conn.createChannel())
     .then((ch) => {
       ch.assertExchange(exchanges.INCOMING_VEHICLE_UPDATES, 'topic', {
-        durable: false,
+        durable: true,
       }).then(() =>
         ch.publish(
           exchanges.INCOMING_VEHICLE_UPDATES,

--- a/packages/driver-interface/src/services/amqp.ts
+++ b/packages/driver-interface/src/services/amqp.ts
@@ -15,7 +15,10 @@ export const updateLocation = (
         ch.publish(
           exchanges.INCOMING_VEHICLE_UPDATES,
           'incoming.updated.location',
-          Buffer.from(JSON.stringify(msg))
+          Buffer.from(JSON.stringify(msg)),
+          {
+            persistent: true,
+          }
         )
       )
     })

--- a/packages/engine-server/lib/engineConnector.js
+++ b/packages/engine-server/lib/engineConnector.js
@@ -58,19 +58,6 @@ module.exports = (io) => {
       return vehicle
     })
 
-  const createBooking = (booking) => {
-    return amqp
-      .exchange('incoming_booking_updates', 'topic', {
-        durable: true,
-      })
-      .publish({ ...booking, assigned_to: null }, routingKeys.REGISTERED)
-      .then(() =>
-        console.log(
-          ` [x] Created booking '${JSON.stringify(booking, null, 2)}'`
-        )
-      )
-  }
-
   const plan = amqp
     .exchange('outgoing_plan_updates', 'fanout', {
       durable: true,
@@ -139,6 +126,21 @@ module.exports = (io) => {
 
   ///////// Publishers
 
+  const createBooking = (booking) => {
+    return amqp
+      .exchange('incoming_booking_updates', 'topic', {
+        durable: true,
+      })
+      .publish({ ...booking, assigned_to: null }, routingKeys.REGISTERED, {
+        persistent: true,
+      })
+      .then(() =>
+        console.log(
+          ` [x] Created booking '${JSON.stringify(booking, null, 2)}'`
+        )
+      )
+  }
+
   const dispatchOffers = () => {
     return amqp
       .queue('dispatch_offers', {
@@ -156,7 +158,10 @@ module.exports = (io) => {
           id: id62(),
           ...vehicle,
         },
-        routingKeys.REGISTERED
+        routingKeys.REGISTERED,
+        {
+          persistent: true,
+        }
       )
   }
 
@@ -165,7 +170,9 @@ module.exports = (io) => {
       .exchange('incoming_booking_updates', 'topic', {
         durable: true,
       })
-      .publish(id, routingKeys.DELETED)
+      .publish(id, routingKeys.DELETED, {
+        persistent: true,
+      })
       .then(() => console.log(` [x] Delete booking ${id}`))
   }
 
@@ -174,7 +181,9 @@ module.exports = (io) => {
       .exchange('incoming_vehicle_updates', 'topic', {
         durable: true,
       })
-      .publish(id, routingKeys.DELETED)
+      .publish(id, routingKeys.DELETED, {
+        persistent: true,
+      })
       .then(() => console.log(` [x] Delete vehicle ${id}`))
   }
 

--- a/packages/engine-server/lib/engineConnector.js
+++ b/packages/engine-server/lib/engineConnector.js
@@ -22,10 +22,10 @@ module.exports = (io) => {
 
   const bookings = amqp
     .exchange('outgoing_booking_updates', 'topic', {
-      durable: false,
+      durable: true,
     })
     .queue('update_booking_in_admin_ui', {
-      durable: false,
+      durable: true,
     })
     .subscribe({ noAck: true }, [
       routingKeys.NEW,
@@ -44,10 +44,10 @@ module.exports = (io) => {
 
   const vehicles = amqp
     .exchange('outgoing_vehicle_updates', 'topic', {
-      durable: false,
+      durable: true,
     })
     .queue('update_vehicle_in_admin_ui', {
-      durable: false,
+      durable: true,
     })
     .subscribe({ noAck: true }, [routingKeys.NEW, routingKeys.NEW_INSTRUCTIONS])
     .map((vehicleRes) => {
@@ -61,7 +61,7 @@ module.exports = (io) => {
   const createBooking = (booking) => {
     return amqp
       .exchange('incoming_booking_updates', 'topic', {
-        durable: false,
+        durable: true,
       })
       .publish({ ...booking, assigned_to: null }, routingKeys.REGISTERED)
       .then(() =>
@@ -73,10 +73,10 @@ module.exports = (io) => {
 
   const plan = amqp
     .exchange('outgoing_plan_updates', 'fanout', {
-      durable: false,
+      durable: true,
     })
     .queue('update_plan_in_admin_ui', {
-      durable: false,
+      durable: true,
     })
     .subscribe({ noAck: true })
     .map((msg) => {
@@ -96,10 +96,10 @@ module.exports = (io) => {
 
   amqp
     .exchange('outgoing_booking_updates', 'topic', {
-      durable: false,
+      durable: true,
     })
     .queue('delete_booking_in_admin_ui', {
-      durable: false,
+      durable: true,
     })
     .subscribe({ noAck: true }, [routingKeys.DELETED])
     .map((bookingData) => bookingData.json())
@@ -113,20 +113,20 @@ module.exports = (io) => {
 
   const transportLocationUpdates = amqp
     .exchange('incoming_vehicle_updates', 'topic', {
-      durable: false,
+      durable: true,
     })
     .queue('update_location.admin_ui', {
-      durable: false,
+      durable: true,
     })
     .subscribe({ noAck: true }, ['incoming.updated.location'])
     .map((res) => res.json())
 
   amqp
     .exchange('outgoing_vehicle_updates', 'topic', {
-      durable: false,
+      durable: true,
     })
     .queue('delete_vehicle_in_admin_ui', {
-      durable: false,
+      durable: true,
     })
     .subscribe({ noAck: true }, [routingKeys.DELETED])
     .map((vehicleData) => vehicleData.json())
@@ -142,7 +142,7 @@ module.exports = (io) => {
   const dispatchOffers = () => {
     return amqp
       .queue('dispatch_offers', {
-        durable: false,
+        durable: true,
         arguments: { 'x-dead-letter-exchange': 'engine_DLX' },
       })
       .publish(JUST_DO_IT_MESSAGE)
@@ -150,7 +150,7 @@ module.exports = (io) => {
 
   const addVehicle = (vehicle) => {
     return amqp
-      .exchange('incoming_vehicle_updates', 'topic', { durable: false })
+      .exchange('incoming_vehicle_updates', 'topic', { durable: true })
       .publish(
         {
           id: id62(),
@@ -163,7 +163,7 @@ module.exports = (io) => {
   const publishDeleteBooking = (id) => {
     return amqp
       .exchange('incoming_booking_updates', 'topic', {
-        durable: false,
+        durable: true,
       })
       .publish(id, routingKeys.DELETED)
       .then(() => console.log(` [x] Delete booking ${id}`))
@@ -172,7 +172,7 @@ module.exports = (io) => {
   const publishDeleteVehicle = (id) => {
     return amqp
       .exchange('incoming_vehicle_updates', 'topic', {
-        durable: false,
+        durable: true,
       })
       .publish(id, routingKeys.DELETED)
       .then(() => console.log(` [x] Delete vehicle ${id}`))
@@ -180,10 +180,10 @@ module.exports = (io) => {
 
   const transportNotifications = amqp
     .exchange('outgoing_vehicle_updates', 'topic', {
-      durable: false,
+      durable: true,
     })
     .queue('transport_notifications.admin_ui', {
-      durable: false,
+      durable: true,
     })
     .subscribe({ noAck: true }, [routingKeys.NEW])
     .map((vehicleRes) => {
@@ -196,10 +196,10 @@ module.exports = (io) => {
 
   const bookingNotifications = amqp
     .exchange('outgoing_booking_updates', 'topic', {
-      durable: false,
+      durable: true,
     })
     .queue('booking_notifications.admin_ui', {
-      durable: false,
+      durable: true,
     })
     .subscribe({ noAck: true }, [
       routingKeys.NEW,

--- a/packages/engine_umbrella/apps/engine/lib/adapters/rabbitMQ.ex
+++ b/packages/engine_umbrella/apps/engine/lib/adapters/rabbitMQ.ex
@@ -42,7 +42,8 @@ defmodule Engine.Adapters.RMQ do
   @impl true
   def handle_call({:publish, data, exchange_name, routing_key}, _, %{channel: channel} = state) do
     Basic.publish(channel, exchange_name, routing_key, Jason.encode!(data),
-      content_type: "application/json"
+      content_type: "application/json",
+      persistent: true
     )
 
     {:reply, data, state}

--- a/packages/engine_umbrella/apps/engine/lib/adapters/rabbitMQ.ex
+++ b/packages/engine_umbrella/apps/engine/lib/adapters/rabbitMQ.ex
@@ -70,9 +70,9 @@ defmodule Engine.Adapters.RMQ do
   end
 
   def setup_resources(channel) do
-    Exchange.declare(channel, @outgoing_plan_exchange, :fanout, durable: false)
-    Exchange.declare(channel, @outgoing_vehicle_exchange, :topic, durable: false)
-    Exchange.declare(channel, @outgoing_booking_exchange, :topic, durable: false)
+    Exchange.declare(channel, @outgoing_plan_exchange, :fanout, durable: true)
+    Exchange.declare(channel, @outgoing_vehicle_exchange, :topic, durable: true)
+    Exchange.declare(channel, @outgoing_booking_exchange, :topic, durable: true)
     Exchange.declare(channel, "engine_DLX", :fanout, durable: true)
 
     Queue.declare(channel, "store_dead_letters.engine", durable: true)

--- a/packages/engine_umbrella/apps/engine/lib/adapters/rabbitMQ_rpc_worker.ex
+++ b/packages/engine_umbrella/apps/engine/lib/adapters/rabbitMQ_rpc_worker.ex
@@ -45,7 +45,8 @@ defmodule Engine.Adapters.RMQRPCWorker do
       queue,
       Jason.encode!(data),
       reply_to: queue_name,
-      correlation_id: correlation_id
+      correlation_id: correlation_id,
+      persistent: true
     )
 
     msg = wait_for_messages(channel, correlation_id)

--- a/packages/engine_umbrella/apps/engine/lib/processors/admin_processor.ex
+++ b/packages/engine_umbrella/apps/engine/lib/processors/admin_processor.ex
@@ -10,7 +10,7 @@ defmodule Engine.AdminProcessor do
           {BroadwayRabbitMQ.Producer,
            after_connect: fn _ -> Logger.info("#{__MODULE__} connected to rabbitmq") end,
            queue: "dispatch_offers",
-           declare: [arguments: [{"x-dead-letter-exchange", "engine_DLX"}]],
+           declare: [arguments: [{"x-dead-letter-exchange", "engine_DLX"}], durable: true],
            on_failure: :reject,
            connection: [
              host: Application.fetch_env!(:engine, :amqp_host)

--- a/packages/engine_umbrella/apps/engine/lib/processors/booking_delete_processor.ex
+++ b/packages/engine_umbrella/apps/engine/lib/processors/booking_delete_processor.ex
@@ -15,7 +15,7 @@ defmodule Engine.BookingDeleteProcessor do
           {BroadwayRabbitMQ.Producer,
            after_connect: fn %AMQP.Channel{} = channel ->
              Logger.info("#{__MODULE__} connected to rabbitmq")
-             AMQP.Exchange.declare(channel, @incoming_booking_exchange, :topic, durable: false)
+             AMQP.Exchange.declare(channel, @incoming_booking_exchange, :topic, durable: true)
            end,
            queue: @delete_booking_queue,
            declare: [arguments: [{"x-dead-letter-exchange", "engine_DLX"}]],

--- a/packages/engine_umbrella/apps/engine/lib/processors/booking_delete_processor.ex
+++ b/packages/engine_umbrella/apps/engine/lib/processors/booking_delete_processor.ex
@@ -18,7 +18,7 @@ defmodule Engine.BookingDeleteProcessor do
              AMQP.Exchange.declare(channel, @incoming_booking_exchange, :topic, durable: true)
            end,
            queue: @delete_booking_queue,
-           declare: [arguments: [{"x-dead-letter-exchange", "engine_DLX"}]],
+           declare: [arguments: [{"x-dead-letter-exchange", "engine_DLX"}], durable: true],
            on_failure: :reject,
            connection: [
              host: Application.fetch_env!(:engine, :amqp_host)

--- a/packages/engine_umbrella/apps/engine/lib/processors/booking_updates_processor.ex
+++ b/packages/engine_umbrella/apps/engine/lib/processors/booking_updates_processor.ex
@@ -16,7 +16,7 @@ defmodule Engine.BookingUpdatesProcessor do
           {BroadwayRabbitMQ.Producer,
            after_connect: fn %AMQP.Channel{} = channel ->
              Logger.info("#{__MODULE__} connected to rabbitmq")
-             AMQP.Exchange.declare(channel, @incoming_booking_exchange, :topic, durable: false)
+             AMQP.Exchange.declare(channel, @incoming_booking_exchange, :topic, durable: true)
            end,
            queue: @update_bookings_statuses_queue,
            connection: [

--- a/packages/engine_umbrella/apps/engine/lib/processors/booking_updates_processor.ex
+++ b/packages/engine_umbrella/apps/engine/lib/processors/booking_updates_processor.ex
@@ -22,7 +22,7 @@ defmodule Engine.BookingUpdatesProcessor do
            connection: [
              host: Application.fetch_env!(:engine, :amqp_host)
            ],
-           declare: [arguments: [{"x-dead-letter-exchange", "engine_DLX"}]],
+           declare: [arguments: [{"x-dead-letter-exchange", "engine_DLX"}], durable: true],
            on_failure: :reject,
            bindings: [
              {@incoming_booking_exchange, routing_key: @picked_up_routing_key},

--- a/packages/engine_umbrella/apps/engine/lib/processors/vehicle_delete_processor.ex
+++ b/packages/engine_umbrella/apps/engine/lib/processors/vehicle_delete_processor.ex
@@ -15,7 +15,7 @@ defmodule Engine.VehicleDeleteProcessor do
           {BroadwayRabbitMQ.Producer,
            after_connect: fn %AMQP.Channel{} = channel ->
              Logger.info("#{__MODULE__} connected to rabbitmq")
-             AMQP.Exchange.declare(channel, @incoming_vehicle_exchange, :topic, durable: false)
+             AMQP.Exchange.declare(channel, @incoming_vehicle_exchange, :topic, durable: true)
            end,
            queue: @delete_vehicle_queue,
            declare: [arguments: [{"x-dead-letter-exchange", "engine_DLX"}]],

--- a/packages/engine_umbrella/apps/engine/lib/processors/vehicle_delete_processor.ex
+++ b/packages/engine_umbrella/apps/engine/lib/processors/vehicle_delete_processor.ex
@@ -18,7 +18,7 @@ defmodule Engine.VehicleDeleteProcessor do
              AMQP.Exchange.declare(channel, @incoming_vehicle_exchange, :topic, durable: true)
            end,
            queue: @delete_vehicle_queue,
-           declare: [arguments: [{"x-dead-letter-exchange", "engine_DLX"}]],
+           declare: [arguments: [{"x-dead-letter-exchange", "engine_DLX"}], durable: true],
            on_failure: :reject,
            connection: [
              host: Application.fetch_env!(:engine, :amqp_host)

--- a/packages/engine_umbrella/apps/engine/lib/producers/match_producer.ex
+++ b/packages/engine_umbrella/apps/engine/lib/producers/match_producer.ex
@@ -43,19 +43,19 @@ defmodule Engine.MatchProducer do
   end
 
   def setup_resources(channel) do
-    Exchange.declare(channel, @incoming_booking_exchange, :topic, durable: false)
-    Exchange.declare(channel, @incoming_vehicle_exchange, :topic, durable: false)
+    Exchange.declare(channel, @incoming_booking_exchange, :topic, durable: true)
+    Exchange.declare(channel, @incoming_vehicle_exchange, :topic, durable: true)
 
     register_new_booking_queue = "register_new_booking"
     register_new_vehicle_queue = "register_new_vehicle"
 
     Queue.declare(channel, register_new_vehicle_queue,
-      durable: false,
+      durable: true,
       arguments: [{"x-dead-letter-exchange", "engine_DLX"}]
     )
 
     Queue.declare(channel, register_new_booking_queue,
-      durable: false,
+      durable: true,
       arguments: [{"x-dead-letter-exchange", "engine_DLX"}]
     )
 

--- a/packages/engine_umbrella/apps/engine/test/booking_updates_processor_test.exs
+++ b/packages/engine_umbrella/apps/engine/test/booking_updates_processor_test.exs
@@ -9,8 +9,8 @@ defmodule BookingUpdatesProcessorTest do
   setup_all do
     {:ok, connection} = AMQP.Connection.open(amqp_url())
     {:ok, channel} = AMQP.Channel.open(connection)
-    AMQP.Queue.declare(channel, "look_for_picked_up_updates_in_test", durable: false)
-    AMQP.Queue.declare(channel, "look_for_delivered_updates_in_test", durable: false)
+    AMQP.Queue.declare(channel, "look_for_picked_up_updates_in_test", durable: true)
+    AMQP.Queue.declare(channel, "look_for_delivered_updates_in_test", durable: true)
 
     AMQP.Queue.bind(channel, "look_for_picked_up_updates_in_test", @outgoing_booking_exchange,
       routing_key: "picked_up"

--- a/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
@@ -24,8 +24,8 @@ defmodule MessageGenerator do
     {:ok, connection} = AMQP.Connection.open(amqp_url())
     {:ok, channel} = AMQP.Channel.open(connection)
 
-    AMQP.Exchange.declare(channel, @bookings_exchange, :topic, durable: false)
-    AMQP.Exchange.declare(channel, @cars_exchange, :topic, durable: false)
+    AMQP.Exchange.declare(channel, @bookings_exchange, :topic, durable: true)
+    AMQP.Exchange.declare(channel, @cars_exchange, :topic, durable: true)
 
     {:ok, channel}
   end
@@ -86,7 +86,7 @@ defmodule MessageGenerator do
   def handle_call(:add_random_booking, _, %{channel: channel} = state) do
     payload =
       random_booking()
-      |> Jason.encode!
+      |> Jason.encode!()
 
     AMQP.Basic.publish(channel, @bookings_exchange, "registered", payload)
 
@@ -97,7 +97,7 @@ defmodule MessageGenerator do
       when is_map(properties) do
     payload =
       random_booking(properties)
-      |> Jason.encode!
+      |> Jason.encode!()
 
     AMQP.Basic.publish(channel, @bookings_exchange, "registered", payload)
 
@@ -109,7 +109,7 @@ defmodule MessageGenerator do
       %{}
       |> add_booking_addresses(city)
       |> random_booking()
-      |> Jason.encode!
+      |> Jason.encode!()
 
     AMQP.Basic.publish(channel, @bookings_exchange, "registered", payload)
 
@@ -119,7 +119,7 @@ defmodule MessageGenerator do
   def handle_call(:add_random_car, _, %{channel: channel} = state) do
     payload =
       random_car()
-      |> Jason.encode!
+      |> Jason.encode!()
 
     AMQP.Basic.publish(channel, @cars_exchange, "registered", payload)
 
@@ -130,7 +130,7 @@ defmodule MessageGenerator do
       when is_map(properties) do
     payload =
       random_car(properties)
-      |> Jason.encode!
+      |> Jason.encode!()
 
     AMQP.Basic.publish(channel, @cars_exchange, "registered", payload)
 
@@ -142,7 +142,7 @@ defmodule MessageGenerator do
       %{}
       |> add_vehicle_addresses(city)
       |> random_car()
-      |> Jason.encode!
+      |> Jason.encode!()
 
     AMQP.Basic.publish(channel, @cars_exchange, "registered", payload)
 

--- a/packages/route-optimization-jsprit/src/main/java/com/predictivemovement/route/optimization/MQApplication.java
+++ b/packages/route-optimization-jsprit/src/main/java/com/predictivemovement/route/optimization/MQApplication.java
@@ -28,7 +28,7 @@ public class MQApplication {
 
 	@Bean
 	public Queue queue() {
-		return new Queue(QUEUE_NAME, false);
+		return new Queue(QUEUE_NAME, true);
 	}
 
 	@Bean


### PR DESCRIPTION
- change rabbitmq to statefulset and configure the data path
- change exchanges and queues to be durable
- publish messages with persistent

Not the easiest to test.
I've tested it on the `predictivemovement-dev` namespace in the k8s cluster and the test was to change from Deployment to a StatefulSet then create a booking while the engine was not running ( so that it doesn't get consumed )
I've restarted the rabbitmq statefulset to see that the queues are still present on restart and the message for the booking was still in the queue

Before running it locally run
```bash
docker-compose stop && \
docker rm $(docker ps -aq --filter="name=predictivemovement_rabbitmq_1") && \
docker-compose build
```