### PR TITLE
chore: validate phone number

### DIFF
--- a/packages/driver-interface/src/services/bot.ts
+++ b/packages/driver-interface/src/services/bot.ts
@@ -16,7 +16,7 @@ export const onLogin = async (
   ctx: TelegrafContext
 ): Promise<Message | void> => {
   const vehicleId = await cache.getVehicleIdByPhoneNumber(
-    phoneNumber.replace('+', '').replace('46', '0')
+    phoneNumber
   )
   const vehicle = await cache.getVehicle(vehicleId)
 

--- a/packages/engine-server/lib/helpers.js
+++ b/packages/engine-server/lib/helpers.js
@@ -1,3 +1,5 @@
+const PhoneNumber = require('awesome-phonenumber')
+
 const severityByEventStatus = (status) => {
   const map = {
     new: 'success',
@@ -36,8 +38,24 @@ const transportToNotification = (transport) => ({
   transport,
 })
 
+const changeFormatOnPhoneNumber = (phoneNumber) => {
+  let phoneNumberData
+  switch (true) {
+    case phoneNumber.startsWith('+'):
+      phoneNumberData = new PhoneNumber(phoneNumber)
+      break
+    case phoneNumber.startsWith('07'):
+      phoneNumberData = new PhoneNumber(phoneNumber, 'SE')
+    default:
+      break
+  }
+
+  return phoneNumberData.getNumber('e164').replace('+', '')
+}
+
 module.exports = {
   severityByEventStatus,
   bookingToNotification,
   transportToNotification,
+  changeFormatOnPhoneNumber,
 }

--- a/packages/engine-server/lib/helpers.js
+++ b/packages/engine-server/lib/helpers.js
@@ -40,16 +40,12 @@ const transportToNotification = (transport) => ({
 
 const changeFormatOnPhoneNumber = (phoneNumber) => {
   let phoneNumberData
-  switch (true) {
-    case phoneNumber.startsWith('+'):
-      phoneNumberData = new PhoneNumber(phoneNumber)
-      break
-    case phoneNumber.startsWith('07'):
-      phoneNumberData = new PhoneNumber(phoneNumber, 'SE')
-    default:
-      break
-  }
 
+  if (phoneNumber.startsWith('+')) {
+    phoneNumberData = new PhoneNumber(phoneNumber)
+  } else if (phoneNumber.startsWith('07')) {
+    phoneNumberData = new PhoneNumber(phoneNumber, 'SE')
+  }
   return phoneNumberData.getNumber('e164').replace('+', '')
 }
 

--- a/packages/engine-server/lib/routes.js
+++ b/packages/engine-server/lib/routes.js
@@ -131,7 +131,10 @@ module.exports = (io) => {
             : params.startPosition,
 
         metadata: {
-          driver: params.driver,
+          driver: {
+            name: params.driver.name,
+            contact: helpers.changeFormatOnPhoneNumber(params.driver.contact),
+          },
           profile: params.vehicleType,
         },
       }

--- a/packages/engine-server/package-lock.json
+++ b/packages/engine-server/package-lock.json
@@ -1012,6 +1012,11 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "awesome-phonenumber": {
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/awesome-phonenumber/-/awesome-phonenumber-2.40.0.tgz",
+      "integrity": "sha512-ViGH+iNPzFCQ1s0Lut8jQC2dP05SjnntlA10emT8ANXy3UtyWykeWvKaDG17eWIcSjXqPvdKkPCco9Nu+Egj1g=="
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",

--- a/packages/engine-server/package.json
+++ b/packages/engine-server/package.json
@@ -26,6 +26,7 @@
     "url": "https://github.com/Iteam1337/pm-mapbox-test/issues"
   },
   "dependencies": {
+    "awesome-phonenumber": "^2.40.0",
     "fluent-amqp": "^0.4.1",
     "highland": "^2.13.5",
     "id62": "^1.0.0",

--- a/packages/engine-ui/src/components/forms/CreateVehicle.js
+++ b/packages/engine-ui/src/components/forms/CreateVehicle.js
@@ -183,9 +183,9 @@ const Component = ({
                 'contact',
                 onChangeHandler
               )}
-              pattern="^(0)\s*(7[0236])\s*(\d{4})\s*(\d{3})$"
+              pattern="^(?:0|[+]46)\s*(7[0236])\s*(\d{4})\s*(\d{3})$"
               required
-              title="07X XX XX XXX"
+              title="07... or +46"
               placeholder="Telefonnummer"
             />
           </Elements.Layout.InputInnerContainer>

--- a/packages/engine-ui/src/components/forms/CreateVehicle.js
+++ b/packages/engine-ui/src/components/forms/CreateVehicle.js
@@ -165,7 +165,9 @@ const Component = ({
           </Elements.Layout.InputInnerContainer>
         </Elements.Layout.InputContainer>
         <Elements.Layout.InputContainer>
-          <Elements.Form.Label htmlFor="contact">Kontakt</Elements.Form.Label>
+          <Elements.Form.Label required htmlFor="contact">
+            Kontakt
+          </Elements.Form.Label>
           <Elements.Layout.InputInnerContainer>
             <Elements.Icons.FormInputIcon
               alt="Contact number icon"
@@ -181,6 +183,9 @@ const Component = ({
                 'contact',
                 onChangeHandler
               )}
+              pattern="^(0)\s*(7[0236])\s*(\d{4})\s*(\d{3})$"
+              required
+              title="07X XX XX XXX"
               placeholder="Telefonnummer"
             />
           </Elements.Layout.InputInnerContainer>


### PR DESCRIPTION
### Admin ui
It is still needed to fill in a phone number in the UI that starts with `07..` or `+46` 

### Engine server 
On the server a new package has been installed to handle formatting for the number. So the number we save and send though the application is ex. `46700 000 000`. 

### Telegram bot
It seems as the number we get when sharing your number is `467...` so for now I just removed the replacing of the phone number.   
 