### PR TITLE
fix: metadata is optional

### DIFF
--- a/packages/engine-ui/src/components/Notifications.tsx
+++ b/packages/engine-ui/src/components/Notifications.tsx
@@ -103,7 +103,7 @@ const Notifications: React.FC<{
             notification.type,
             messageElementFromNotification(notification),
             notification.type === EntityType.TRANSPORT
-              ? notification.transport.metadata.profile
+              ? notification.transport.metadata?.profile
               : undefined
           )}
         </NotificationComponent>

--- a/packages/engine-ui/src/components/PlanRouteDetails.tsx
+++ b/packages/engine-ui/src/components/PlanRouteDetails.tsx
@@ -111,7 +111,7 @@ const PlanRouteDetails = ({ route, routeNumber, color }: Props) => {
                 panMapView(route.start_address.lat, route.start_address.lon)
               }
             >
-              {route.metadata.profile?.toUpperCase() ||
+              {route.metadata?.profile?.toUpperCase() ||
                 helpers.getLastFourChars(route.id).toUpperCase()}
             </Elements.Links.RoundedLink>
           </Elements.Layout.FlexRowWrapper>

--- a/packages/engine-ui/src/components/TransportDetails.tsx
+++ b/packages/engine-ui/src/components/TransportDetails.tsx
@@ -99,7 +99,7 @@ const TransportDetails: React.FC<{
             margin="0 0.5rem"
             backgroundColor={transport.color}
           >
-            {transport.metadata.profile?.toUpperCase() ||
+            {transport.metadata?.profile?.toUpperCase() ||
               helpers.getLastFourChars(transportId).toUpperCase()}
           </Elements.Typography.RoundedLabelDisplay>
         </Elements.Layout.FlexRowWrapper>

--- a/packages/engine-ui/src/components/TransportsList.tsx
+++ b/packages/engine-ui/src/components/TransportsList.tsx
@@ -48,7 +48,7 @@ const TransportsList: React.FC<{ transports: Transport[] }> = ({
               )
             }
           >
-            {transport.metadata.profile?.toUpperCase() ||
+            {transport.metadata?.profile?.toUpperCase() ||
               helpers.getLastFourChars(transport.id).toUpperCase()}
           </Elements.Links.RoundedLink>
         </li>

--- a/packages/engine-ui/src/types.ts
+++ b/packages/engine-ui/src/types.ts
@@ -76,7 +76,7 @@ export type Transport = {
   end_address: Address
   id: string
   latest_end: Date
-  metadata: { profile?: string }
+  metadata?: { profile?: string }
   name?: string
   start_address: Address
 }
@@ -105,7 +105,7 @@ export interface Route {
   end_address: Address
   id: string
   latest_end: Date
-  metadata: { profile?: string }
+  metadata?: { profile?: string }
   start_address: Address
 }
 


### PR DESCRIPTION
If metadata isn't provided, which we aren't currently not enforcing, the UI will crash unless these checks are in place.