### PR TITLE
chore: clean message generator

### DIFF
--- a/packages/engine_umbrella/apps/engine/test/booking_processor_test.exs
+++ b/packages/engine_umbrella/apps/engine/test/booking_processor_test.exs
@@ -53,20 +53,24 @@ defmodule BookingProcessorTest do
   end
 
   test "creates a plan for two vehicles, where each vehicle gets one" do
-    TransportGenerator.generate_transport()
+    %{}
     |> TransportGenerator.put_new_transport_addresses_from_city(:stockholm)
+    |> TransportGenerator.generate_transport()
     |> Vehicle.make()
 
-    TransportGenerator.generate_transport()
+    %{}
     |> TransportGenerator.put_new_transport_addresses_from_city(:gothenburg)
+    |> TransportGenerator.generate_transport()
     |> Vehicle.make()
 
-    BookingGenerator.generate_booking()
+    %{}
     |> BookingGenerator.put_new_booking_addresses_from_city(:stockholm)
+    |> BookingGenerator.generate_booking()
     |> Booking.make()
 
-    BookingGenerator.generate_booking()
+    %{}
     |> BookingGenerator.put_new_booking_addresses_from_city(:gothenburg)
+    |> BookingGenerator.generate_booking()
     |> Booking.make()
 
     vehicle_ids = Engine.VehicleStore.get_vehicles()

--- a/packages/engine_umbrella/apps/engine/test/booking_processor_test.exs
+++ b/packages/engine_umbrella/apps/engine/test/booking_processor_test.exs
@@ -8,10 +8,10 @@ defmodule BookingProcessorTest do
   use ExUnit.Case
 
   test "creates a plan for one vehicle and one booking" do
-    TransportGenerator.generate_transport()
+    TransportGenerator.generate_transport_props()
     |> Vehicle.make()
 
-    BookingGenerator.generate_booking()
+    BookingGenerator.generate_booking_props()
     |> Booking.make()
 
     vehicle_ids = Engine.VehicleStore.get_vehicles()
@@ -26,19 +26,19 @@ defmodule BookingProcessorTest do
   end
 
   test "creates a plan where one vehicle gets two bookings and one gets zero" do
-    TransportGenerator.generate_transport()
+    TransportGenerator.generate_transport_props()
     |> TransportGenerator.put_new_transport_addresses_from_city(:stockholm)
     |> Vehicle.make()
 
-    TransportGenerator.generate_transport()
+    TransportGenerator.generate_transport_props()
     |> TransportGenerator.put_new_transport_addresses_from_city(:gothenburg)
     |> Vehicle.make()
 
-    BookingGenerator.generate_booking()
+    BookingGenerator.generate_booking_props()
     |> BookingGenerator.put_new_booking_addresses_from_city(:stockholm)
     |> Booking.make()
 
-    BookingGenerator.generate_booking()
+    BookingGenerator.generate_booking_props()
     |> BookingGenerator.put_new_booking_addresses_from_city(:stockholm)
     |> Booking.make()
 
@@ -55,22 +55,22 @@ defmodule BookingProcessorTest do
   test "creates a plan for two vehicles, where each vehicle gets one" do
     %{}
     |> TransportGenerator.put_new_transport_addresses_from_city(:stockholm)
-    |> TransportGenerator.generate_transport()
+    |> TransportGenerator.generate_transport_props()
     |> Vehicle.make()
 
     %{}
     |> TransportGenerator.put_new_transport_addresses_from_city(:gothenburg)
-    |> TransportGenerator.generate_transport()
+    |> TransportGenerator.generate_transport_props()
     |> Vehicle.make()
 
     %{}
     |> BookingGenerator.put_new_booking_addresses_from_city(:stockholm)
-    |> BookingGenerator.generate_booking()
+    |> BookingGenerator.generate_booking_props()
     |> Booking.make()
 
     %{}
     |> BookingGenerator.put_new_booking_addresses_from_city(:gothenburg)
-    |> BookingGenerator.generate_booking()
+    |> BookingGenerator.generate_booking_props()
     |> Booking.make()
 
     vehicle_ids = Engine.VehicleStore.get_vehicles()
@@ -93,10 +93,12 @@ defmodule BookingProcessorTest do
   end
 
   test "vehicle with no end_address defined gets start_address as end_address" do
-    TransportGenerator.generate_transport(%{start_address: %{lat: 61.829182, lon: 16.0896213}})
+    TransportGenerator.generate_transport_props(%{
+      start_address: %{lat: 61.829182, lon: 16.0896213}
+    })
     |> Vehicle.make()
 
-    BookingGenerator.generate_booking()
+    BookingGenerator.generate_booking_props()
     |> Booking.make()
 
     vehicle_ids = Engine.VehicleStore.get_vehicles()
@@ -112,13 +114,13 @@ defmodule BookingProcessorTest do
   end
 
   test "vehicle with end_address defined" do
-    TransportGenerator.generate_transport(%{
+    TransportGenerator.generate_transport_props(%{
       start_address: %{lat: 61.829182, lon: 16.0896213},
       end_address: %{lat: 51.829182, lon: 17.0896213}
     })
     |> Vehicle.make()
 
-    BookingGenerator.generate_booking()
+    BookingGenerator.generate_booking_props()
     |> Booking.make()
 
     vehicle_ids = Engine.VehicleStore.get_vehicles()
@@ -137,13 +139,13 @@ defmodule BookingProcessorTest do
     earliest_start = "12:05"
     latest_end = "18:05"
 
-    TransportGenerator.generate_transport(%{
+    TransportGenerator.generate_transport_props(%{
       earliest_start: earliest_start,
       latest_end: latest_end
     })
     |> Vehicle.make()
 
-    BookingGenerator.generate_booking()
+    BookingGenerator.generate_booking_props()
     |> Booking.make()
 
     vehicle_ids = Engine.VehicleStore.get_vehicles()
@@ -163,12 +165,12 @@ defmodule BookingProcessorTest do
   end
 
   test "capacity is included in the plan" do
-    TransportGenerator.generate_transport(%{
+    TransportGenerator.generate_transport_props(%{
       capacity: %{weight: 731, volume: 18}
     })
     |> Vehicle.make()
 
-    BookingGenerator.generate_booking(%{
+    BookingGenerator.generate_booking_props(%{
       size: %{measurements: [14, 12, 10], weight: 1}
     })
     |> Booking.make()
@@ -186,12 +188,12 @@ defmodule BookingProcessorTest do
   end
 
   test "vehicle with too small storage doesn't get assigned" do
-    TransportGenerator.generate_transport(%{
+    TransportGenerator.generate_transport_props(%{
       capacity: %{weight: 700, volume: 1}
     })
     |> Vehicle.make()
 
-    BookingGenerator.generate_booking(%{
+    BookingGenerator.generate_booking_props(%{
       size: %{measurements: [100, 100, 101], weight: 2}
     })
     |> Booking.make()
@@ -206,12 +208,12 @@ defmodule BookingProcessorTest do
   end
 
   test "vehicle with too little weight capabilities doesn't get assigned" do
-    TransportGenerator.generate_transport(%{
+    TransportGenerator.generate_transport_props(%{
       capacity: %{weight: 50, volume: 18}
     })
     |> Vehicle.make()
 
-    BookingGenerator.generate_booking(%{
+    BookingGenerator.generate_booking_props(%{
       size: %{measurements: [14, 12, 10], weight: 100}
     })
     |> Booking.make()
@@ -226,22 +228,22 @@ defmodule BookingProcessorTest do
   end
 
   test "bookings with same pickup should work just fine" do
-    BookingGenerator.generate_booking(%{
+    BookingGenerator.generate_booking_props(%{
       pickup: %{lat: 61.829182, lon: 16.0896213}
     })
     |> Booking.make()
 
-    BookingGenerator.generate_booking(%{
+    BookingGenerator.generate_booking_props(%{
       pickup: %{lat: 61.829182, lon: 16.0896213}
     })
     |> Booking.make()
 
-    BookingGenerator.generate_booking(%{
+    BookingGenerator.generate_booking_props(%{
       delivery: %{lat: 61.829182, lon: 16.0896213}
     })
     |> Booking.make()
 
-    TransportGenerator.generate_transport(%{start_address: %{lat: 60.1111, lon: 16.07544}})
+    TransportGenerator.generate_transport_props(%{start_address: %{lat: 60.1111, lon: 16.07544}})
     |> Vehicle.make()
 
     vehicle_ids = Engine.VehicleStore.get_vehicles()
@@ -256,7 +258,7 @@ defmodule BookingProcessorTest do
 
   test "constraints failures leads to excluded bookings" do
     expected_id =
-      BookingGenerator.generate_booking(%{
+      BookingGenerator.generate_booking_props(%{
         id: "Gammelstad->LTU",
         metadata: %{
           start: "Gammelstad (65.641574, 22.015858) -> LTU (65.61582, 22.13488)"
@@ -281,7 +283,7 @@ defmodule BookingProcessorTest do
       )
       |> Booking.make()
 
-    BookingGenerator.generate_booking(%{
+    BookingGenerator.generate_booking_props(%{
       id: "Gäddvik->LTU",
       metadata: %{
         start: "Gäddvik (65.581598, 22.051736) -> LTU (65.61582, 22.13488)"
@@ -300,7 +302,7 @@ defmodule BookingProcessorTest do
     )
     |> Booking.make()
 
-    TransportGenerator.generate_transport(%{
+    TransportGenerator.generate_transport_props(%{
       id: "vehicle-1",
       start_address: %{
         lon: 21.92567,

--- a/packages/engine_umbrella/apps/engine/test/booking_processor_test.exs
+++ b/packages/engine_umbrella/apps/engine/test/booking_processor_test.exs
@@ -1,14 +1,17 @@
 defmodule BookingProcessorTest do
   import TestHelper
+  alias MessageGenerator.TransportGenerator
+  alias MessageGenerator.BookingGenerator
+
   def amqp_url, do: "amqp://" <> Application.fetch_env!(:engine, :amqp_host)
   @outgoing_plan_exchange Application.compile_env!(:engine, :outgoing_plan_exchange)
   use ExUnit.Case
 
   test "creates a plan for one vehicle and one booking" do
-    MessageGenerator.random_car()
+    TransportGenerator.generate_transport()
     |> Vehicle.make()
 
-    MessageGenerator.random_booking()
+    BookingGenerator.generate_booking()
     |> Booking.make()
 
     vehicle_ids = Engine.VehicleStore.get_vehicles()
@@ -23,20 +26,20 @@ defmodule BookingProcessorTest do
   end
 
   test "creates a plan where one vehicle gets two bookings and one gets zero" do
-    MessageGenerator.random_car()
-    |> MessageGenerator.add_vehicle_addresses(:stockholm)
+    TransportGenerator.generate_transport()
+    |> TransportGenerator.put_new_transport_addresses_from_city(:stockholm)
     |> Vehicle.make()
 
-    MessageGenerator.random_car()
-    |> MessageGenerator.add_vehicle_addresses(:gothenburg)
+    TransportGenerator.generate_transport()
+    |> TransportGenerator.put_new_transport_addresses_from_city(:gothenburg)
     |> Vehicle.make()
 
-    MessageGenerator.random_booking()
-    |> MessageGenerator.add_booking_addresses(:stockholm)
+    BookingGenerator.generate_booking()
+    |> BookingGenerator.put_new_booking_addresses_from_city(:stockholm)
     |> Booking.make()
 
-    MessageGenerator.random_booking()
-    |> MessageGenerator.add_booking_addresses(:stockholm)
+    BookingGenerator.generate_booking()
+    |> BookingGenerator.put_new_booking_addresses_from_city(:stockholm)
     |> Booking.make()
 
     vehicle_ids = Engine.VehicleStore.get_vehicles()
@@ -50,20 +53,20 @@ defmodule BookingProcessorTest do
   end
 
   test "creates a plan for two vehicles, where each vehicle gets one" do
-    MessageGenerator.random_car()
-    |> MessageGenerator.add_vehicle_addresses(:stockholm)
+    TransportGenerator.generate_transport()
+    |> TransportGenerator.put_new_transport_addresses_from_city(:stockholm)
     |> Vehicle.make()
 
-    MessageGenerator.random_car()
-    |> MessageGenerator.add_vehicle_addresses(:gothenburg)
+    TransportGenerator.generate_transport()
+    |> TransportGenerator.put_new_transport_addresses_from_city(:gothenburg)
     |> Vehicle.make()
 
-    MessageGenerator.random_booking()
-    |> MessageGenerator.add_booking_addresses(:stockholm)
+    BookingGenerator.generate_booking()
+    |> BookingGenerator.put_new_booking_addresses_from_city(:stockholm)
     |> Booking.make()
 
-    MessageGenerator.random_booking()
-    |> MessageGenerator.add_booking_addresses(:gothenburg)
+    BookingGenerator.generate_booking()
+    |> BookingGenerator.put_new_booking_addresses_from_city(:gothenburg)
     |> Booking.make()
 
     vehicle_ids = Engine.VehicleStore.get_vehicles()
@@ -86,10 +89,10 @@ defmodule BookingProcessorTest do
   end
 
   test "vehicle with no end_address defined gets start_address as end_address" do
-    MessageGenerator.random_car(%{start_address: %{lat: 61.829182, lon: 16.0896213}})
+    TransportGenerator.generate_transport(%{start_address: %{lat: 61.829182, lon: 16.0896213}})
     |> Vehicle.make()
 
-    MessageGenerator.random_booking()
+    BookingGenerator.generate_booking()
     |> Booking.make()
 
     vehicle_ids = Engine.VehicleStore.get_vehicles()
@@ -105,13 +108,13 @@ defmodule BookingProcessorTest do
   end
 
   test "vehicle with end_address defined" do
-    MessageGenerator.random_car(%{
+    TransportGenerator.generate_transport(%{
       start_address: %{lat: 61.829182, lon: 16.0896213},
       end_address: %{lat: 51.829182, lon: 17.0896213}
     })
     |> Vehicle.make()
 
-    MessageGenerator.random_booking()
+    BookingGenerator.generate_booking()
     |> Booking.make()
 
     vehicle_ids = Engine.VehicleStore.get_vehicles()
@@ -130,10 +133,13 @@ defmodule BookingProcessorTest do
     earliest_start = "12:05"
     latest_end = "18:05"
 
-    MessageGenerator.random_car(%{earliest_start: earliest_start, latest_end: latest_end})
+    TransportGenerator.generate_transport(%{
+      earliest_start: earliest_start,
+      latest_end: latest_end
+    })
     |> Vehicle.make()
 
-    MessageGenerator.random_booking()
+    BookingGenerator.generate_booking()
     |> Booking.make()
 
     vehicle_ids = Engine.VehicleStore.get_vehicles()
@@ -153,12 +159,12 @@ defmodule BookingProcessorTest do
   end
 
   test "capacity is included in the plan" do
-    MessageGenerator.random_car(%{
+    TransportGenerator.generate_transport(%{
       capacity: %{weight: 731, volume: 18}
     })
     |> Vehicle.make()
 
-    MessageGenerator.random_booking(%{
+    BookingGenerator.generate_booking(%{
       size: %{measurements: [14, 12, 10], weight: 1}
     })
     |> Booking.make()
@@ -176,12 +182,12 @@ defmodule BookingProcessorTest do
   end
 
   test "vehicle with too small storage doesn't get assigned" do
-    MessageGenerator.random_car(%{
+    TransportGenerator.generate_transport(%{
       capacity: %{weight: 700, volume: 1}
     })
     |> Vehicle.make()
 
-    MessageGenerator.random_booking(%{
+    BookingGenerator.generate_booking(%{
       size: %{measurements: [100, 100, 101], weight: 2}
     })
     |> Booking.make()
@@ -196,12 +202,12 @@ defmodule BookingProcessorTest do
   end
 
   test "vehicle with too little weight capabilities doesn't get assigned" do
-    MessageGenerator.random_car(%{
+    TransportGenerator.generate_transport(%{
       capacity: %{weight: 50, volume: 18}
     })
     |> Vehicle.make()
 
-    MessageGenerator.random_booking(%{
+    BookingGenerator.generate_booking(%{
       size: %{measurements: [14, 12, 10], weight: 100}
     })
     |> Booking.make()
@@ -216,22 +222,22 @@ defmodule BookingProcessorTest do
   end
 
   test "bookings with same pickup should work just fine" do
-    MessageGenerator.random_booking(%{
+    BookingGenerator.generate_booking(%{
       pickup: %{lat: 61.829182, lon: 16.0896213}
     })
     |> Booking.make()
 
-    MessageGenerator.random_booking(%{
+    BookingGenerator.generate_booking(%{
       pickup: %{lat: 61.829182, lon: 16.0896213}
     })
     |> Booking.make()
 
-    MessageGenerator.random_booking(%{
+    BookingGenerator.generate_booking(%{
       delivery: %{lat: 61.829182, lon: 16.0896213}
     })
     |> Booking.make()
 
-    MessageGenerator.random_car(%{start_address: %{lat: 60.1111, lon: 16.07544}})
+    TransportGenerator.generate_transport(%{start_address: %{lat: 60.1111, lon: 16.07544}})
     |> Vehicle.make()
 
     vehicle_ids = Engine.VehicleStore.get_vehicles()
@@ -246,7 +252,7 @@ defmodule BookingProcessorTest do
 
   test "constraints failures leads to excluded bookings" do
     expected_id =
-      MessageGenerator.random_booking(%{
+      BookingGenerator.generate_booking(%{
         id: "Gammelstad->LTU",
         metadata: %{
           start: "Gammelstad (65.641574, 22.015858) -> LTU (65.61582, 22.13488)"
@@ -271,7 +277,7 @@ defmodule BookingProcessorTest do
       )
       |> Booking.make()
 
-    MessageGenerator.random_booking(%{
+    BookingGenerator.generate_booking(%{
       id: "Gäddvik->LTU",
       metadata: %{
         start: "Gäddvik (65.581598, 22.051736) -> LTU (65.61582, 22.13488)"
@@ -290,7 +296,7 @@ defmodule BookingProcessorTest do
     )
     |> Booking.make()
 
-    MessageGenerator.random_car(%{
+    TransportGenerator.generate_transport(%{
       id: "vehicle-1",
       start_address: %{
         lon: 21.92567,

--- a/packages/engine_umbrella/apps/engine/test/booking_test.exs
+++ b/packages/engine_umbrella/apps/engine/test/booking_test.exs
@@ -5,7 +5,7 @@ defmodule BookingTest do
 
   test "it allows booking creation" do
     result =
-      BookingGenerator.generate_booking()
+      BookingGenerator.generate_booking_props()
       |> Booking.make()
 
     assert is_binary(result)
@@ -14,7 +14,7 @@ defmodule BookingTest do
 
   test "does not allow malformed size (weight)" do
     result =
-      BookingGenerator.generate_booking(%{
+      BookingGenerator.generate_booking_props(%{
         size: %{measurements: [14, 12, 10], weight: 1.2}
       })
       |> Booking.make()
@@ -24,7 +24,7 @@ defmodule BookingTest do
 
   test "does not allow malformed size (measurements)" do
     result =
-      BookingGenerator.generate_booking(%{
+      BookingGenerator.generate_booking_props(%{
         size: %{measurements: "12", weight: 1}
       })
       |> Booking.make()
@@ -37,7 +37,7 @@ defmodule BookingTest do
 
   test "does not allow malformed measurements elements" do
     result =
-      BookingGenerator.generate_booking(%{
+      BookingGenerator.generate_booking_props(%{
         size: %{measurements: ["12"], weight: 1}
       })
       |> Booking.make()
@@ -50,7 +50,7 @@ defmodule BookingTest do
 
   test "does not allow incomplete measurements" do
     result =
-      BookingGenerator.generate_booking(%{
+      BookingGenerator.generate_booking_props(%{
         size: %{measurements: [12], weight: 1}
       })
       |> Booking.make()
@@ -60,7 +60,7 @@ defmodule BookingTest do
 
   test "allows correct measurements" do
     result =
-      BookingGenerator.generate_booking(%{
+      BookingGenerator.generate_booking_props(%{
         size: %{measurements: [12, 14, 15], weight: 1}
       })
       |> Booking.make()
@@ -71,7 +71,7 @@ defmodule BookingTest do
 
   test "should validate booking addresses containing lat/lon" do
     result =
-      BookingGenerator.generate_booking()
+      BookingGenerator.generate_booking_props()
       |> Map.put(:pickup, %{city: "", name: "hafdoajgjagia", street: ""})
       |> Map.put(:delivery, %{city: "", name: "hafdoajgjagia", street: ""})
       |> Booking.make()
@@ -86,7 +86,7 @@ defmodule BookingTest do
 
   test "should validate booking addresses lat/lon in correct format" do
     result =
-      BookingGenerator.generate_booking()
+      BookingGenerator.generate_booking_props()
       |> Map.put(:pickup, %{
         lat: "2321321",
         lon: "dkdsakjdsa",
@@ -112,14 +112,14 @@ defmodule BookingTest do
   end
 
   test "requires that delivery is present" do
-    BookingGenerator.generate_booking()
+    BookingGenerator.generate_booking_props()
     |> Map.delete(:delivery)
     |> Booking.make()
     |> catch_error()
   end
 
   test "requires that pickup is present" do
-    BookingGenerator.generate_booking()
+    BookingGenerator.generate_booking_props()
     |> Map.delete(:pickup)
     |> Booking.make()
     |> catch_error()
@@ -127,7 +127,7 @@ defmodule BookingTest do
 
   test "should allow booking to be updated" do
     id =
-      BookingGenerator.generate_booking()
+      BookingGenerator.generate_booking_props()
       |> Booking.make()
 
     updated_booking = %{
@@ -150,7 +150,7 @@ defmodule BookingTest do
 
   test "allows for only updating delivery" do
     id =
-      BookingGenerator.generate_booking()
+      BookingGenerator.generate_booking_props()
       |> Booking.make()
 
     new_delivery = %{lat: 13.37, lon: 13.37}
@@ -166,7 +166,7 @@ defmodule BookingTest do
 
   test "allows for only updating pickup" do
     id =
-      BookingGenerator.generate_booking()
+      BookingGenerator.generate_booking_props()
       |> Booking.make()
 
     new_pickup = %{lat: 13.37, lon: 13.37}
@@ -182,7 +182,7 @@ defmodule BookingTest do
 
   test "allows for only updating size" do
     id =
-      BookingGenerator.generate_booking()
+      BookingGenerator.generate_booking_props()
       |> Booking.make()
 
     new_size = %{measurements: [222, 2, 2], weight: 100}

--- a/packages/engine_umbrella/apps/engine/test/booking_test.exs
+++ b/packages/engine_umbrella/apps/engine/test/booking_test.exs
@@ -1,10 +1,11 @@
 defmodule BookingTest do
   import TestHelper
+  alias MessageGenerator.BookingGenerator
   use ExUnit.Case
 
   test "it allows booking creation" do
     result =
-      MessageGenerator.random_booking()
+      BookingGenerator.generate_booking()
       |> Booking.make()
 
     assert is_binary(result)
@@ -13,7 +14,7 @@ defmodule BookingTest do
 
   test "does not allow malformed size (weight)" do
     result =
-      MessageGenerator.random_booking(%{
+      BookingGenerator.generate_booking(%{
         size: %{measurements: [14, 12, 10], weight: 1.2}
       })
       |> Booking.make()
@@ -23,7 +24,7 @@ defmodule BookingTest do
 
   test "does not allow malformed size (measurements)" do
     result =
-      MessageGenerator.random_booking(%{
+      BookingGenerator.generate_booking(%{
         size: %{measurements: "12", weight: 1}
       })
       |> Booking.make()
@@ -36,7 +37,7 @@ defmodule BookingTest do
 
   test "does not allow malformed measurements elements" do
     result =
-      MessageGenerator.random_booking(%{
+      BookingGenerator.generate_booking(%{
         size: %{measurements: ["12"], weight: 1}
       })
       |> Booking.make()
@@ -49,7 +50,7 @@ defmodule BookingTest do
 
   test "does not allow incomplete measurements" do
     result =
-      MessageGenerator.random_booking(%{
+      BookingGenerator.generate_booking(%{
         size: %{measurements: [12], weight: 1}
       })
       |> Booking.make()
@@ -59,7 +60,7 @@ defmodule BookingTest do
 
   test "allows correct measurements" do
     result =
-      MessageGenerator.random_booking(%{
+      BookingGenerator.generate_booking(%{
         size: %{measurements: [12, 14, 15], weight: 1}
       })
       |> Booking.make()
@@ -70,7 +71,7 @@ defmodule BookingTest do
 
   test "should validate booking addresses containing lat/lon" do
     result =
-      MessageGenerator.random_booking()
+      BookingGenerator.generate_booking()
       |> Map.put(:pickup, %{city: "", name: "hafdoajgjagia", street: ""})
       |> Map.put(:delivery, %{city: "", name: "hafdoajgjagia", street: ""})
       |> Booking.make()
@@ -85,7 +86,7 @@ defmodule BookingTest do
 
   test "should validate booking addresses lat/lon in correct format" do
     result =
-      MessageGenerator.random_booking()
+      BookingGenerator.generate_booking()
       |> Map.put(:pickup, %{
         lat: "2321321",
         lon: "dkdsakjdsa",
@@ -111,14 +112,14 @@ defmodule BookingTest do
   end
 
   test "requires that delivery is present" do
-    MessageGenerator.random_booking()
+    BookingGenerator.generate_booking()
     |> Map.delete(:delivery)
     |> Booking.make()
     |> catch_error()
   end
 
   test "requires that pickup is present" do
-    MessageGenerator.random_booking()
+    BookingGenerator.generate_booking()
     |> Map.delete(:pickup)
     |> Booking.make()
     |> catch_error()
@@ -126,7 +127,7 @@ defmodule BookingTest do
 
   test "should allow booking to be updated" do
     id =
-      MessageGenerator.random_booking()
+      BookingGenerator.generate_booking()
       |> Booking.make()
 
     updated_booking = %{
@@ -149,7 +150,7 @@ defmodule BookingTest do
 
   test "allows for only updating delivery" do
     id =
-      MessageGenerator.random_booking()
+      BookingGenerator.generate_booking()
       |> Booking.make()
 
     new_delivery = %{lat: 13.37, lon: 13.37}
@@ -165,7 +166,7 @@ defmodule BookingTest do
 
   test "allows for only updating pickup" do
     id =
-      MessageGenerator.random_booking()
+      BookingGenerator.generate_booking()
       |> Booking.make()
 
     new_pickup = %{lat: 13.37, lon: 13.37}
@@ -181,7 +182,7 @@ defmodule BookingTest do
 
   test "allows for only updating size" do
     id =
-      MessageGenerator.random_booking()
+      BookingGenerator.generate_booking()
       |> Booking.make()
 
     new_size = %{measurements: [222, 2, 2], weight: 100}

--- a/packages/engine_umbrella/apps/engine/test/vehicle_test.exs
+++ b/packages/engine_umbrella/apps/engine/test/vehicle_test.exs
@@ -1,10 +1,11 @@
 defmodule VehicleTest do
   import TestHelper
+  alias MessageGenerator.TransportGenerator
   use ExUnit.Case
 
   test "it allows vehicle creation" do
     result =
-      MessageGenerator.random_car()
+      TransportGenerator.generate_transport()
       |> Vehicle.make()
 
     assert is_binary(result)
@@ -29,7 +30,7 @@ defmodule VehicleTest do
 
   test "does not allow malformed time constraints" do
     result =
-      MessageGenerator.random_car(%{earliest_start: "foo", latest_end: "bar"})
+      TransportGenerator.generate_transport(%{earliest_start: "foo", latest_end: "bar"})
       |> Vehicle.make()
 
     assert result == [
@@ -45,7 +46,7 @@ defmodule VehicleTest do
 
   test "does not allow non integer weight capacity" do
     result =
-      MessageGenerator.random_car(%{
+      TransportGenerator.generate_transport(%{
         capacity: %{volume: 2, weight: 13.4}
       })
       |> Vehicle.make()
@@ -55,7 +56,7 @@ defmodule VehicleTest do
 
   test "does not allow non integer volume capacity" do
     result =
-      MessageGenerator.random_car(%{earliest_start: "foo", latest_end: "bar"})
+      TransportGenerator.generate_transport(%{earliest_start: "foo", latest_end: "bar"})
       |> Vehicle.make()
 
     assert result == [
@@ -66,7 +67,7 @@ defmodule VehicleTest do
 
   test "should validate addresses containing lat/lon" do
     result =
-      MessageGenerator.random_car(%{
+      TransportGenerator.generate_transport(%{
         capacity: %{volume: 1, weight: 123},
         earliest_start: nil,
         latest_end: nil,
@@ -85,7 +86,7 @@ defmodule VehicleTest do
 
   test "should validate addresses lat/lon in correct format" do
     result =
-      MessageGenerator.random_car(%{
+      TransportGenerator.generate_transport(%{
         capacity: %{volume: 1, weight: 123},
         earliest_start: nil,
         latest_end: nil,
@@ -110,7 +111,7 @@ defmodule VehicleTest do
 
   test "should allow vehicle to be updated" do
     id =
-      MessageGenerator.random_car()
+      TransportGenerator.generate_transport()
       |> Vehicle.make()
 
     updated_vehicle = %{

--- a/packages/engine_umbrella/apps/engine/test/vehicle_test.exs
+++ b/packages/engine_umbrella/apps/engine/test/vehicle_test.exs
@@ -5,7 +5,7 @@ defmodule VehicleTest do
 
   test "it allows vehicle creation" do
     result =
-      TransportGenerator.generate_transport()
+      TransportGenerator.generate_transport_props()
       |> Vehicle.make()
 
     assert is_binary(result)
@@ -30,7 +30,7 @@ defmodule VehicleTest do
 
   test "does not allow malformed time constraints" do
     result =
-      TransportGenerator.generate_transport(%{earliest_start: "foo", latest_end: "bar"})
+      TransportGenerator.generate_transport_props(%{earliest_start: "foo", latest_end: "bar"})
       |> Vehicle.make()
 
     assert result == [
@@ -46,7 +46,7 @@ defmodule VehicleTest do
 
   test "does not allow non integer weight capacity" do
     result =
-      TransportGenerator.generate_transport(%{
+      TransportGenerator.generate_transport_props(%{
         capacity: %{volume: 2, weight: 13.4}
       })
       |> Vehicle.make()
@@ -56,7 +56,7 @@ defmodule VehicleTest do
 
   test "does not allow non integer volume capacity" do
     result =
-      TransportGenerator.generate_transport(%{earliest_start: "foo", latest_end: "bar"})
+      TransportGenerator.generate_transport_props(%{earliest_start: "foo", latest_end: "bar"})
       |> Vehicle.make()
 
     assert result == [
@@ -67,7 +67,7 @@ defmodule VehicleTest do
 
   test "should validate addresses containing lat/lon" do
     result =
-      TransportGenerator.generate_transport(%{
+      TransportGenerator.generate_transport_props(%{
         capacity: %{volume: 1, weight: 123},
         earliest_start: nil,
         latest_end: nil,
@@ -86,7 +86,7 @@ defmodule VehicleTest do
 
   test "should validate addresses lat/lon in correct format" do
     result =
-      TransportGenerator.generate_transport(%{
+      TransportGenerator.generate_transport_props(%{
         capacity: %{volume: 1, weight: 123},
         earliest_start: nil,
         latest_end: nil,
@@ -111,7 +111,7 @@ defmodule VehicleTest do
 
   test "should allow vehicle to be updated" do
     id =
-      TransportGenerator.generate_transport()
+      TransportGenerator.generate_transport_props()
       |> Vehicle.make()
 
     updated_vehicle = %{

--- a/packages/engine_umbrella/apps/message_generator/lib/adapters/rabbitMQ.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/adapters/rabbitMQ.ex
@@ -1,0 +1,84 @@
+defmodule MessageGenerator.Adapters.RMQ do
+  use GenServer
+  require Logger
+  alias AMQP.{Exchange, Queue, Channel, Basic, Connection}
+
+  defp amqp_url, do: "amqp://" <> Application.fetch_env!(:engine, :amqp_host)
+
+  @outgoing_vehicle_exchange Application.compile_env!(:engine, :outgoing_vehicle_exchange)
+  @outgoing_booking_exchange Application.compile_env!(:engine, :outgoing_booking_exchange)
+  @outgoing_plan_exchange Application.compile_env!(:engine, :outgoing_plan_exchange)
+  @reconnect_interval 5_000
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @impl true
+  def init(_) do
+    send(self(), :connect)
+
+    {:ok, %{conn: nil, channel: nil}}
+  end
+
+  def publish(data, exchange_name) do
+    GenServer.call(__MODULE__, {:publish, data, exchange_name, ""})
+  end
+
+  def publish(data, exchange_name, routing_key) do
+    GenServer.call(__MODULE__, {:publish, data, exchange_name, routing_key})
+  end
+
+  def get_connection do
+    case GenServer.call(__MODULE__, :get_connection) do
+      nil -> {:error, :not_connected}
+      conn -> {:ok, conn}
+    end
+  end
+
+  @impl true
+  def handle_call(:get_connection, _, %{conn: conn} = state), do: {:reply, conn, state}
+
+  @impl true
+  def handle_call({:publish, data, exchange_name, routing_key}, _, %{channel: channel} = state) do
+    Basic.publish(channel, exchange_name, routing_key, Jason.encode!(data),
+      content_type: "application/json",
+      persistent: true
+    )
+
+    {:reply, data, state}
+  end
+
+  @impl true
+  def handle_info(:connect, current_state) do
+    with {:ok, conn} <- Connection.open(amqp_url()),
+         {:ok, channel} <- Channel.open(conn),
+         :ok <- setup_resources(channel) do
+      Process.monitor(conn.pid)
+      Logger.info("#{__MODULE__} connected to rabbitmq")
+      {:noreply, %{conn: conn, channel: channel}}
+    else
+      _ ->
+        Logger.error("Failed to connect #{amqp_url()}. Reconnecting later...")
+        Process.send_after(self(), :connect, @reconnect_interval)
+        {:noreply, current_state}
+    end
+  end
+
+  @impl true
+  def handle_info({:DOWN, _, :process, _pid, reason}, _) do
+    {:stop, {:connection_lost, reason}, nil}
+  end
+
+  def setup_resources(channel) do
+    Exchange.declare(channel, @outgoing_plan_exchange, :fanout, durable: true)
+    Exchange.declare(channel, @outgoing_vehicle_exchange, :topic, durable: true)
+    Exchange.declare(channel, @outgoing_booking_exchange, :topic, durable: true)
+    Exchange.declare(channel, "engine_DLX", :fanout, durable: true)
+
+    Queue.declare(channel, "store_dead_letters.engine", durable: true)
+    Queue.bind(channel, "store_dead_letters.engine", "engine_DLX")
+
+    :ok
+  end
+end

--- a/packages/engine_umbrella/apps/message_generator/lib/booking_generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/booking_generator.ex
@@ -1,0 +1,32 @@
+defmodule MessageGenerator.BookingGenerator do
+  alias MessageGenerator.Address
+
+  @stockholm %{lat: 59.3414072, lon: 18.0470482}
+  @gothenburg %{lat: 57.7009147, lon: 11.7537571}
+  @ljusdal %{lat: 61.829182, lon: 16.0896213}
+
+  def generate_booking(properties \\ %{}) do
+    properties
+    |> Map.put_new(:externalId, Enum.random(0..100_000))
+    |> put_new_booking_addresses_from_city(:ljusdal)
+    |> Map.put_new(:size, %{measurements: [105, 55, 26], weight: Enum.random(1..200)})
+    |> Map.put_new(:metadata, %{
+      sender: %{contact: "0701234567"},
+      recipient: %{contact: "0701234567"}
+    })
+  end
+
+  def put_new_booking_addresses_from_city(map), do: do_add_booking_addresses(map, @ljusdal)
+
+  def put_new_booking_addresses_from_city(map, :stockholm),
+    do: do_add_booking_addresses(map, @stockholm)
+
+  def put_new_booking_addresses_from_city(map, :gothenburg),
+    do: do_add_booking_addresses(map, @gothenburg)
+
+  defp do_add_booking_addresses(map, location) do
+    map
+    |> Map.put_new(:pickup, Address.random(location))
+    |> Map.put_new(:delivery, Address.random(location))
+  end
+end

--- a/packages/engine_umbrella/apps/message_generator/lib/booking_generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/booking_generator.ex
@@ -16,7 +16,8 @@ defmodule MessageGenerator.BookingGenerator do
     })
   end
 
-  def put_new_booking_addresses_from_city(map), do: do_add_booking_addresses(map, @ljusdal)
+  def put_new_booking_addresses_from_city(map, :ljusdal),
+    do: do_add_booking_addresses(map, @ljusdal)
 
   def put_new_booking_addresses_from_city(map, :stockholm),
     do: do_add_booking_addresses(map, @stockholm)

--- a/packages/engine_umbrella/apps/message_generator/lib/booking_generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/booking_generator.ex
@@ -5,7 +5,7 @@ defmodule MessageGenerator.BookingGenerator do
   @gothenburg %{lat: 57.7009147, lon: 11.7537571}
   @ljusdal %{lat: 61.829182, lon: 16.0896213}
 
-  def generate_booking(properties \\ %{}) do
+  def generate_booking_props(properties \\ %{}) do
     properties
     |> Map.put_new(:externalId, Enum.random(0..100_000))
     |> put_new_booking_addresses_from_city(:ljusdal)

--- a/packages/engine_umbrella/apps/message_generator/lib/generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/generator.ex
@@ -1,0 +1,32 @@
+defmodule MessageGenerator.Generator do
+  alias MessageGenerator.Address
+
+  @stockholm %{lat: 59.3414072, lon: 18.0470482}
+  @gothenburg %{lat: 57.7009147, lon: 11.7537571}
+  @ljusdal %{lat: 61.829182, lon: 16.0896213}
+
+  def add_booking_addresses(map), do: do_add_booking_addresses(map, @ljusdal)
+  def add_booking_addresses(map, :stockholm), do: do_add_booking_addresses(map, @stockholm)
+  def add_booking_addresses(map, :gothenburg), do: do_add_booking_addresses(map, @gothenburg)
+
+  defp do_add_booking_addresses(map, location) do
+    map
+    |> Map.put_new(:pickup, Address.random(location))
+    |> Map.put_new(:delivery, Address.random(location))
+  end
+
+  def put_new_transport_addresses_from_city(map, :ljusdal),
+    do: do_add_transport_addresses(map, @ljusdal)
+
+  def put_new_transport_addresses_from_city(map, :stockholm),
+    do: do_add_transport_addresses(map, @stockholm)
+
+  def put_new_transport_addresses_from_city(map, :gothenburg),
+    do: do_add_transport_addresses(map, @gothenburg)
+
+  defp do_add_transport_addresses(map, location) do
+    map
+    |> Map.put_new(:start_address, Address.random(location))
+    |> Map.put_new(:end_address, Address.random(location))
+  end
+end

--- a/packages/engine_umbrella/apps/message_generator/lib/generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/generator.ex
@@ -1,4 +1,4 @@
-defmodule MessageGenerator do
+defmodule Generator do
   alias MessageGenerator.Adapters.RMQ
   alias MessageGenerator.TransportGenerator
   alias MessageGenerator.BookingGenerator

--- a/packages/engine_umbrella/apps/message_generator/lib/generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/generator.ex
@@ -5,9 +5,13 @@ defmodule MessageGenerator.Generator do
   @gothenburg %{lat: 57.7009147, lon: 11.7537571}
   @ljusdal %{lat: 61.829182, lon: 16.0896213}
 
-  def add_booking_addresses(map), do: do_add_booking_addresses(map, @ljusdal)
-  def add_booking_addresses(map, :stockholm), do: do_add_booking_addresses(map, @stockholm)
-  def add_booking_addresses(map, :gothenburg), do: do_add_booking_addresses(map, @gothenburg)
+  def put_new_booking_addresses_from_city(map), do: do_add_booking_addresses(map, @ljusdal)
+
+  def put_new_booking_addresses_from_city(map, :stockholm),
+    do: do_add_booking_addresses(map, @stockholm)
+
+  def put_new_booking_addresses_from_city(map, :gothenburg),
+    do: do_add_booking_addresses(map, @gothenburg)
 
   defp do_add_booking_addresses(map, location) do
     map

--- a/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
@@ -24,17 +24,6 @@ defmodule MessageGenerator do
     |> Generator.put_new_transport_addresses_from_city(:ljusdal)
   end
 
-  def generate_booking(properties \\ %{}) do
-    properties
-    |> Map.put_new(:externalId, Enum.random(0..100_000))
-    |> Generator.add_booking_addresses()
-    |> Map.put_new(:size, %{measurements: [105, 55, 26], weight: Enum.random(1..200)})
-    |> Map.put_new(:metadata, %{
-      sender: %{contact: "0701234567"},
-      recipient: %{contact: "0701234567"}
-    })
-  end
-
   def add_random_booking(properties \\ %{})
 
   def add_random_booking(properties) when is_map(properties) do
@@ -44,8 +33,19 @@ defmodule MessageGenerator do
 
   def add_random_booking(city) when city in [:stockholm, :gothenburg] do
     %{}
-    |> Generator.add_booking_addresses(city)
+    |> Generator.put_new_booking_addresses_from_city(city)
     |> generate_booking()
     |> RMQ.publish(@bookings_exchange, "registered")
+  end
+
+  def generate_booking(properties \\ %{}) do
+    properties
+    |> Map.put_new(:externalId, Enum.random(0..100_000))
+    |> Generator.put_new_booking_addresses_from_city(:ljusdal)
+    |> Map.put_new(:size, %{measurements: [105, 55, 26], weight: Enum.random(1..200)})
+    |> Map.put_new(:metadata, %{
+      sender: %{contact: "0701234567"},
+      recipient: %{contact: "0701234567"}
+    })
   end
 end

--- a/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
@@ -30,12 +30,10 @@ defmodule MessageGenerator do
     %{}
     |> Map.put(:start_address, Address.random(@ljusdal))
     |> Map.put(:end_address, Address.random(@ljusdal))
-    |> Map.put(:id, Enum.random(0..100_000))
   end
 
   def generate_transport(properties) when is_map(properties) do
     properties
-    |> Map.put(:id, Enum.random(0..100_000))
     |> Map.put_new(:start_address, Address.random(@ljusdal))
   end
 

--- a/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
@@ -6,28 +6,28 @@ defmodule MessageGenerator do
   @transports_exchange "incoming_vehicle_updates"
   @bookings_exchange "incoming_booking_updates"
 
-  def add_random_transport(properties \\ %{})
+  def add_transport(properties \\ %{})
 
-  def add_random_transport(properties) when is_map(properties) do
+  def add_transport(properties) when is_map(properties) do
     TransportGenerator.generate_transport_props(properties)
     |> RMQ.publish(@transports_exchange, "registered")
   end
 
-  def add_random_transport(city) when city in [:stockholm, :gothenburg] do
+  def add_transport(city) when city in [:stockholm, :gothenburg] do
     %{}
     |> TransportGenerator.put_new_transport_addresses_from_city(city)
     |> TransportGenerator.generate_transport_props()
     |> RMQ.publish(@transports_exchange, "registered")
   end
 
-  def add_random_booking(properties \\ %{})
+  def add_booking(properties \\ %{})
 
-  def add_random_booking(properties) when is_map(properties) do
+  def add_booking(properties) when is_map(properties) do
     BookingGenerator.generate_booking_props(properties)
     |> RMQ.publish(@bookings_exchange, "registered")
   end
 
-  def add_random_booking(city) when city in [:stockholm, :gothenburg] do
+  def add_booking(city) when city in [:stockholm, :gothenburg] do
     %{}
     |> BookingGenerator.put_new_booking_addresses_from_city(city)
     |> BookingGenerator.generate_booking_props()

--- a/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
@@ -9,10 +9,7 @@ defmodule MessageGenerator do
   @gothenburg %{lat: 57.7009147, lon: 11.7537571}
   @ljusdal %{lat: 61.829182, lon: 16.0896213}
 
-  def add_random_transport() do
-    generate_transport()
-    |> RMQ.publish(@transports_exchange, "registered")
-  end
+  def add_random_transport(properties \\ %{})
 
   def add_random_transport(properties) when is_map(properties) do
     generate_transport(properties)
@@ -26,13 +23,7 @@ defmodule MessageGenerator do
     |> RMQ.publish(@transports_exchange, "registered")
   end
 
-  def generate_transport() do
-    %{}
-    |> Map.put(:start_address, Address.random(@ljusdal))
-    |> Map.put(:end_address, Address.random(@ljusdal))
-  end
-
-  def generate_transport(properties) when is_map(properties) do
+  def generate_transport(properties \\ %{}) do
     properties
     |> Map.put_new(:start_address, Address.random(@ljusdal))
   end

--- a/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
@@ -1,13 +1,9 @@
 defmodule MessageGenerator do
-  alias MessageGenerator.Address
   alias MessageGenerator.Adapters.RMQ
+  alias MessageGenerator.Generator
 
   @transports_exchange "incoming_vehicle_updates"
   @bookings_exchange "incoming_booking_updates"
-
-  @stockholm %{lat: 59.3414072, lon: 18.0470482}
-  @gothenburg %{lat: 57.7009147, lon: 11.7537571}
-  @ljusdal %{lat: 61.829182, lon: 16.0896213}
 
   def add_random_transport(properties \\ %{})
 
@@ -18,30 +14,20 @@ defmodule MessageGenerator do
 
   def add_random_transport(city) when city in [:stockholm, :gothenburg] do
     %{}
-    |> add_transport_addresses(city)
+    |> Generator.put_new_transport_addresses_from_city(city)
     |> generate_transport()
     |> RMQ.publish(@transports_exchange, "registered")
   end
 
   def generate_transport(properties \\ %{}) do
     properties
-    |> Map.put_new(:start_address, Address.random(@ljusdal))
-  end
-
-  def add_transport_addresses(map), do: do_add_transport_addresses(map, @ljusdal)
-  def add_transport_addresses(map, :stockholm), do: do_add_transport_addresses(map, @stockholm)
-  def add_transport_addresses(map, :gothenburg), do: do_add_transport_addresses(map, @gothenburg)
-
-  defp do_add_transport_addresses(map, location) do
-    map
-    |> Map.put(:start_address, Address.random(location))
-    |> Map.put(:end_address, Address.random(location))
+    |> Generator.put_new_transport_addresses_from_city(:ljusdal)
   end
 
   def generate_booking(properties \\ %{}) do
     properties
     |> Map.put_new(:externalId, Enum.random(0..100_000))
-    |> add_booking_addresses()
+    |> Generator.add_booking_addresses()
     |> Map.put_new(:size, %{measurements: [105, 55, 26], weight: Enum.random(1..200)})
     |> Map.put_new(:metadata, %{
       sender: %{contact: "0701234567"},
@@ -58,18 +44,8 @@ defmodule MessageGenerator do
 
   def add_random_booking(city) when city in [:stockholm, :gothenburg] do
     %{}
-    |> add_booking_addresses(city)
+    |> Generator.add_booking_addresses(city)
     |> generate_booking()
     |> RMQ.publish(@bookings_exchange, "registered")
-  end
-
-  def add_booking_addresses(map), do: do_add_booking_addresses(map, @ljusdal)
-  def add_booking_addresses(map, :stockholm), do: do_add_booking_addresses(map, @stockholm)
-  def add_booking_addresses(map, :gothenburg), do: do_add_booking_addresses(map, @gothenburg)
-
-  defp do_add_booking_addresses(map, location) do
-    map
-    |> Map.put(:pickup, Address.random(location))
-    |> Map.put(:delivery, Address.random(location))
   end
 end

--- a/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
@@ -9,28 +9,28 @@ defmodule MessageGenerator do
   def add_random_transport(properties \\ %{})
 
   def add_random_transport(properties) when is_map(properties) do
-    TransportGenerator.generate_transport(properties)
+    TransportGenerator.generate_transport_props(properties)
     |> RMQ.publish(@transports_exchange, "registered")
   end
 
   def add_random_transport(city) when city in [:stockholm, :gothenburg] do
     %{}
     |> TransportGenerator.put_new_transport_addresses_from_city(city)
-    |> TransportGenerator.generate_transport()
+    |> TransportGenerator.generate_transport_props()
     |> RMQ.publish(@transports_exchange, "registered")
   end
 
   def add_random_booking(properties \\ %{})
 
   def add_random_booking(properties) when is_map(properties) do
-    BookingGenerator.generate_booking(properties)
+    BookingGenerator.generate_booking_props(properties)
     |> RMQ.publish(@bookings_exchange, "registered")
   end
 
   def add_random_booking(city) when city in [:stockholm, :gothenburg] do
     %{}
     |> BookingGenerator.put_new_booking_addresses_from_city(city)
-    |> BookingGenerator.generate_booking()
+    |> BookingGenerator.generate_booking_props()
     |> RMQ.publish(@bookings_exchange, "registered")
   end
 end

--- a/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
@@ -1,5 +1,4 @@
 defmodule MessageGenerator do
-  use GenServer
   alias MessageGenerator.Address
   alias MessageGenerator.Adapters.RMQ
 
@@ -9,14 +8,6 @@ defmodule MessageGenerator do
   @stockholm %{lat: 59.3414072, lon: 18.0470482}
   @gothenburg %{lat: 57.7009147, lon: 11.7537571}
   @ljusdal %{lat: 61.829182, lon: 16.0896213}
-
-  def start_link(_opts) do
-    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
-  end
-
-  def init(_) do
-    {:ok, %{}}
-  end
 
   def add_random_transport() do
     generate_transport()

--- a/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
@@ -3,7 +3,7 @@ defmodule MessageGenerator do
   alias MessageGenerator.Address
   alias MessageGenerator.Adapters.RMQ
 
-  @cars_exchange "incoming_vehicle_updates"
+  @transports_exchange "incoming_vehicle_updates"
   @bookings_exchange "incoming_booking_updates"
 
   @stockholm %{lat: 59.3414072, lon: 18.0470482}
@@ -18,31 +18,31 @@ defmodule MessageGenerator do
     {:ok, %{}}
   end
 
-  def add_random_car() do
-    generate_car()
-    |> RMQ.publish(@cars_exchange, "registered")
+  def add_random_transport() do
+    generate_transport()
+    |> RMQ.publish(@transports_exchange, "registered")
   end
 
-  def add_random_car(properties) when is_map(properties) do
-    generate_car(properties)
-    |> RMQ.publish(@cars_exchange, "registered")
+  def add_random_transport(properties) when is_map(properties) do
+    generate_transport(properties)
+    |> RMQ.publish(@transports_exchange, "registered")
   end
 
-  def add_random_car(city) when city in [:stockholm, :gothenburg] do
+  def add_random_transport(city) when city in [:stockholm, :gothenburg] do
     %{}
     |> add_vehicle_addresses(city)
-    |> generate_car()
-    |> RMQ.publish(@cars_exchange, "registered")
+    |> generate_transport()
+    |> RMQ.publish(@transports_exchange, "registered")
   end
 
-  def generate_car() do
+  def generate_transport() do
     %{}
     |> Map.put(:start_address, Address.random(@ljusdal))
     |> Map.put(:end_address, Address.random(@ljusdal))
     |> Map.put(:id, Enum.random(0..100_000))
   end
 
-  def generate_car(properties) when is_map(properties) do
+  def generate_transport(properties) when is_map(properties) do
     properties
     |> Map.put(:id, Enum.random(0..100_000))
     |> Map.put_new(:start_address, Address.random(@ljusdal))

--- a/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
@@ -18,7 +18,7 @@ defmodule MessageGenerator do
 
   def add_random_transport(city) when city in [:stockholm, :gothenburg] do
     %{}
-    |> add_vehicle_addresses(city)
+    |> add_transport_addresses(city)
     |> generate_transport()
     |> RMQ.publish(@transports_exchange, "registered")
   end
@@ -28,11 +28,11 @@ defmodule MessageGenerator do
     |> Map.put_new(:start_address, Address.random(@ljusdal))
   end
 
-  def add_vehicle_addresses(map), do: do_add_vehicle_addresses(map, @ljusdal)
-  def add_vehicle_addresses(map, :stockholm), do: do_add_vehicle_addresses(map, @stockholm)
-  def add_vehicle_addresses(map, :gothenburg), do: do_add_vehicle_addresses(map, @gothenburg)
+  def add_transport_addresses(map), do: do_add_transport_addresses(map, @ljusdal)
+  def add_transport_addresses(map, :stockholm), do: do_add_transport_addresses(map, @stockholm)
+  def add_transport_addresses(map, :gothenburg), do: do_add_transport_addresses(map, @gothenburg)
 
-  defp do_add_vehicle_addresses(map, location) do
+  defp do_add_transport_addresses(map, location) do
     map
     |> Map.put(:start_address, Address.random(location))
     |> Map.put(:end_address, Address.random(location))

--- a/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
@@ -5,10 +5,9 @@ defmodule MessageGenerator do
 
   @cars_exchange "incoming_vehicle_updates"
   @bookings_exchange "incoming_booking_updates"
+
   @stockholm %{lat: 59.3414072, lon: 18.0470482}
-
   @gothenburg %{lat: 57.7009147, lon: 11.7537571}
-
   @ljusdal %{lat: 61.829182, lon: 16.0896213}
 
   def start_link(_opts) do
@@ -19,19 +18,44 @@ defmodule MessageGenerator do
     {:ok, %{}}
   end
 
-  def random_car(), do: random_car(@ljusdal)
+  def add_random_car() do
+    generate_car()
+    |> RMQ.publish(@cars_exchange, "registered")
+  end
 
-  def random_car(properties) when is_map(properties) do
+  def add_random_car(properties) when is_map(properties) do
+    generate_car(properties)
+    |> RMQ.publish(@cars_exchange, "registered")
+  end
+
+  def add_random_car(city) when city in [:stockholm, :gothenburg] do
+    %{}
+    |> add_vehicle_addresses(city)
+    |> generate_car()
+    |> RMQ.publish(@cars_exchange, "registered")
+  end
+
+  def generate_car() do
+    %{}
+    |> Map.put(:start_address, Address.random(@ljusdal))
+    |> Map.put(:end_address, Address.random(@ljusdal))
+    |> Map.put(:id, Enum.random(0..100_000))
+  end
+
+  def generate_car(properties) when is_map(properties) do
     properties
     |> Map.put(:id, Enum.random(0..100_000))
     |> Map.put_new(:start_address, Address.random(@ljusdal))
   end
 
-  def random_car(location) do
-    %{}
+  def add_vehicle_addresses(map), do: do_add_vehicle_addresses(map, @ljusdal)
+  def add_vehicle_addresses(map, :stockholm), do: do_add_vehicle_addresses(map, @stockholm)
+  def add_vehicle_addresses(map, :gothenburg), do: do_add_vehicle_addresses(map, @gothenburg)
+
+  defp do_add_vehicle_addresses(map, location) do
+    map
     |> Map.put(:start_address, Address.random(location))
     |> Map.put(:end_address, Address.random(location))
-    |> Map.put(:id, Enum.random(0..100_000))
   end
 
   def random_booking(), do: random_booking(@ljusdal)
@@ -54,14 +78,7 @@ defmodule MessageGenerator do
     |> Map.put(:size, %{measurements: [105, 55, 26], weight: Enum.random(1..200)})
   end
 
-  def add_random_car(), do: GenServer.call(__MODULE__, :add_random_car)
   def add_random_booking(), do: GenServer.call(__MODULE__, :add_random_booking)
-
-  def add_random_car(properties) when is_map(properties),
-    do: GenServer.call(__MODULE__, {:add_random_car, properties})
-
-  def add_random_car(:stockholm), do: GenServer.call(__MODULE__, {:add_random_car, :stockholm})
-  def add_random_car(:gothenburg), do: GenServer.call(__MODULE__, {:add_random_car, :gothenburg})
 
   def add_random_booking(properties) when is_map(properties),
     do: GenServer.call(__MODULE__, {:add_random_booking, properties})
@@ -73,9 +90,7 @@ defmodule MessageGenerator do
     do: GenServer.call(__MODULE__, {:add_random_booking, :gothenburg})
 
   def handle_call(:add_random_booking, _, state) do
-    payload =
-      random_booking()
-      |> Jason.encode!()
+    payload = random_booking()
 
     RMQ.publish(payload, @bookings_exchange, "registered")
 
@@ -84,9 +99,7 @@ defmodule MessageGenerator do
 
   def handle_call({:add_random_booking, properties}, _, state)
       when is_map(properties) do
-    payload =
-      random_booking(properties)
-      |> Jason.encode!()
+    payload = random_booking(properties)
 
     RMQ.publish(payload, @bookings_exchange, "registered")
 
@@ -98,54 +111,10 @@ defmodule MessageGenerator do
       %{}
       |> add_booking_addresses(city)
       |> random_booking()
-      |> Jason.encode!()
 
     RMQ.publish(payload, @bookings_exchange, "registered")
 
     {:reply, :ok, state}
-  end
-
-  def handle_call(:add_random_car, _, state) do
-    payload =
-      random_car()
-      |> Jason.encode!()
-
-    RMQ.publish(payload, @cars_exchange, "registered")
-
-    {:reply, :ok, state}
-  end
-
-  def handle_call({:add_random_car, properties}, _, state)
-      when is_map(properties) do
-    payload =
-      random_car(properties)
-      |> Jason.encode!()
-
-    RMQ.publish(payload, @cars_exchange, "registered")
-
-    {:reply, :ok, state}
-  end
-
-  def handle_call({:add_random_car, city}, _, state) do
-    payload =
-      %{}
-      |> add_vehicle_addresses(city)
-      |> random_car()
-      |> Jason.encode!()
-
-    RMQ.publish(payload, @cars_exchange, "registered")
-
-    {:reply, :ok, state}
-  end
-
-  def add_vehicle_addresses(map), do: do_add_vehicle_addresses(map, @ljusdal)
-  def add_vehicle_addresses(map, :stockholm), do: do_add_vehicle_addresses(map, @stockholm)
-  def add_vehicle_addresses(map, :gothenburg), do: do_add_vehicle_addresses(map, @gothenburg)
-
-  defp do_add_vehicle_addresses(map, location) do
-    map
-    |> Map.put(:start_address, Address.random(location))
-    |> Map.put(:end_address, Address.random(location))
   end
 
   def add_booking_addresses(map), do: do_add_booking_addresses(map, @ljusdal)

--- a/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/message_generator.ex
@@ -1,6 +1,7 @@
 defmodule MessageGenerator do
   alias MessageGenerator.Adapters.RMQ
-  alias MessageGenerator.Generator
+  alias MessageGenerator.TransportGenerator
+  alias MessageGenerator.BookingGenerator
 
   @transports_exchange "incoming_vehicle_updates"
   @bookings_exchange "incoming_booking_updates"
@@ -8,44 +9,28 @@ defmodule MessageGenerator do
   def add_random_transport(properties \\ %{})
 
   def add_random_transport(properties) when is_map(properties) do
-    generate_transport(properties)
+    TransportGenerator.generate_transport(properties)
     |> RMQ.publish(@transports_exchange, "registered")
   end
 
   def add_random_transport(city) when city in [:stockholm, :gothenburg] do
     %{}
-    |> Generator.put_new_transport_addresses_from_city(city)
-    |> generate_transport()
+    |> TransportGenerator.put_new_transport_addresses_from_city(city)
+    |> TransportGenerator.generate_transport()
     |> RMQ.publish(@transports_exchange, "registered")
-  end
-
-  def generate_transport(properties \\ %{}) do
-    properties
-    |> Generator.put_new_transport_addresses_from_city(:ljusdal)
   end
 
   def add_random_booking(properties \\ %{})
 
   def add_random_booking(properties) when is_map(properties) do
-    generate_booking(properties)
+    BookingGenerator.generate_booking(properties)
     |> RMQ.publish(@bookings_exchange, "registered")
   end
 
   def add_random_booking(city) when city in [:stockholm, :gothenburg] do
     %{}
-    |> Generator.put_new_booking_addresses_from_city(city)
-    |> generate_booking()
+    |> BookingGenerator.put_new_booking_addresses_from_city(city)
+    |> BookingGenerator.generate_booking()
     |> RMQ.publish(@bookings_exchange, "registered")
-  end
-
-  def generate_booking(properties \\ %{}) do
-    properties
-    |> Map.put_new(:externalId, Enum.random(0..100_000))
-    |> Generator.put_new_booking_addresses_from_city(:ljusdal)
-    |> Map.put_new(:size, %{measurements: [105, 55, 26], weight: Enum.random(1..200)})
-    |> Map.put_new(:metadata, %{
-      sender: %{contact: "0701234567"},
-      recipient: %{contact: "0701234567"}
-    })
   end
 end

--- a/packages/engine_umbrella/apps/message_generator/lib/message_generator/application.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/message_generator/application.ex
@@ -8,7 +8,7 @@ defmodule MessageGenerator.Application do
   def start(_type, _args) do
     children = [
       # Starts a worker by calling: MessageGenerator.Worker.start_link(arg)
-      MessageGenerator
+      MessageGenerator.Adapters.RMQ
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/packages/engine_umbrella/apps/message_generator/lib/transport_generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/transport_generator.ex
@@ -22,6 +22,5 @@ defmodule MessageGenerator.TransportGenerator do
   defp do_add_transport_addresses(map, location) do
     map
     |> Map.put_new(:start_address, Address.random(location))
-    |> Map.put_new(:end_address, Address.random(location))
   end
 end

--- a/packages/engine_umbrella/apps/message_generator/lib/transport_generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/transport_generator.ex
@@ -5,7 +5,7 @@ defmodule MessageGenerator.TransportGenerator do
   @gothenburg %{lat: 57.7009147, lon: 11.7537571}
   @ljusdal %{lat: 61.829182, lon: 16.0896213}
 
-  def generate_transport(properties \\ %{}) do
+  def generate_transport_props(properties \\ %{}) do
     properties
     |> put_new_transport_addresses_from_city(:ljusdal)
   end

--- a/packages/engine_umbrella/apps/message_generator/lib/transport_generator.ex
+++ b/packages/engine_umbrella/apps/message_generator/lib/transport_generator.ex
@@ -1,22 +1,13 @@
-defmodule MessageGenerator.Generator do
+defmodule MessageGenerator.TransportGenerator do
   alias MessageGenerator.Address
 
   @stockholm %{lat: 59.3414072, lon: 18.0470482}
   @gothenburg %{lat: 57.7009147, lon: 11.7537571}
   @ljusdal %{lat: 61.829182, lon: 16.0896213}
 
-  def put_new_booking_addresses_from_city(map), do: do_add_booking_addresses(map, @ljusdal)
-
-  def put_new_booking_addresses_from_city(map, :stockholm),
-    do: do_add_booking_addresses(map, @stockholm)
-
-  def put_new_booking_addresses_from_city(map, :gothenburg),
-    do: do_add_booking_addresses(map, @gothenburg)
-
-  defp do_add_booking_addresses(map, location) do
-    map
-    |> Map.put_new(:pickup, Address.random(location))
-    |> Map.put_new(:delivery, Address.random(location))
+  def generate_transport(properties \\ %{}) do
+    properties
+    |> put_new_transport_addresses_from_city(:ljusdal)
   end
 
   def put_new_transport_addresses_from_city(map, :ljusdal),

--- a/packages/engine_umbrella/apps/message_generator/mix.exs
+++ b/packages/engine_umbrella/apps/message_generator/mix.exs
@@ -15,7 +15,6 @@ defmodule MessageGenerator.MixProject do
     ]
   end
 
-  # Run "mix help compile.app" to learn about applications.
   def application do
     [
       env: [
@@ -26,15 +25,13 @@ defmodule MessageGenerator.MixProject do
     ]
   end
 
-  # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      {:jason, "~> 1.2"},
       {:poison, "~> 3.1"},
       {:httpoison, "~> 1.6"},
       {:amqp, "~> 1.4"},
       {:hackney, git: "https://github.com/benoitc/hackney.git", branch: "master", override: true}
-      # {:dep_from_hexpm, "~> 0.3.0"},
-      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
     ]
   end
 end


### PR DESCRIPTION
This cleans up the message generator and makes it follow the same RMQ pattern as the engine.

the public API is now renamed as 
Generator.add_booking
Generator.add_transport

with the option of inserting a map with props that should not be overwritten
or a atom which sets the city for the transport/booking.
