### PR TITLE
feat: driver delivery receipt

### DIFF
--- a/packages/driver-interface/src/botRoutes.ts
+++ b/packages/driver-interface/src/botRoutes.ts
@@ -62,8 +62,9 @@ export const init = (bot: Telegraf<TelegrafContext>): void => {
           telegramId,
           instructionGroupId
         )
-      case 'picked_up':
       case 'delivered':
+        cache.setDriverDoneDelivering(telegramId)
+      case 'picked_up':
       case 'delivery_failed': {
         return cache
           .getAndDeleteInstructionGroup(instructionGroupId)

--- a/packages/driver-interface/src/services/bot.ts
+++ b/packages/driver-interface/src/services/bot.ts
@@ -3,7 +3,11 @@ import cache from './cache'
 import { v4 as uuid } from 'uuid'
 
 import * as messaging from './messaging'
-import { IncomingMessage, Message } from 'telegraf/typings/telegram-types'
+import {
+  IncomingMessage,
+  Message,
+  PhotoSize,
+} from 'telegraf/typings/telegram-types'
 import { TelegrafContext } from 'telegraf/typings/context'
 import { Instruction } from '../types'
 
@@ -157,37 +161,34 @@ export const handleDriverArrivedToPickupOrDeliveryPosition = async (
   }
 }
 
-export const onPhotoReceived = async ({
-  from: { id: telegramId },
-  photo: photoArray,
-}: {
-  from?: { id: number }
-  photo?: any
-}) => {
+export const onPhotoReceived = async (
+  telegramId: number,
+  photoSizes: PhotoSize[]
+): Promise<Message> => {
   const bookingIds = await cache.getDriverCurrentDelivering(telegramId)
-  if (bookingIds) {
-    const highestResPhotoId = photoArray[photoArray.length - 1].file_id
-    return cache
-      .getDeliveryReceiptPhotos(bookingIds)
-      .then((photoIds: string[]) =>
-        cache.saveDeliveryReceiptPhoto(
-          bookingIds,
-          photoIds.concat([highestResPhotoId])
-        )
+  if (!bookingIds) return messaging.sendCouldNotSavePhoto(telegramId)
+  const highestResPhotoId = photoSizes[photoSizes.length - 1].file_id
+  return cache
+    .getDeliveryReceiptPhotos(bookingIds)
+    .then((photoIds: string[]) =>
+      cache.saveDeliveryReceiptPhoto(
+        bookingIds,
+        photoIds.concat([highestResPhotoId])
       )
-      .then(() => messaging.sendPhotoReceived(telegramId))
-  }
+    )
+    .then(() => messaging.sendPhotoReceived(telegramId))
 }
 
 export const beginDeliveryAcknowledgement = async (
   telegramId: number,
   instructionGroupId: string
-) => {
-  return cache
+): Promise<Message> =>
+  cache
     .getInstructionGroup(instructionGroupId)
-    .then((instructionGroup) => instructionGroup.map(({ id }) => id))
-    .then((bookingIds) =>
+    .then((instructionGroup: Instruction[]) =>
+      instructionGroup.map(({ id }) => id)
+    )
+    .then((bookingIds: string[]) =>
       cache.setDriverCurrentlyDelivering(telegramId, bookingIds)
     )
     .then(() => messaging.sendBeginDeliveryAcknowledgement(telegramId))
-}

--- a/packages/driver-interface/src/services/cache.ts
+++ b/packages/driver-interface/src/services/cache.ts
@@ -78,6 +78,8 @@ export default {
       `${keys.CURRENTLY_DELIVERING}:${telegramId}`,
       JSON.stringify(bookindIds)
     ),
+  setDriverDoneDelivering: (telegramId: number): Promise<number> =>
+    redis.del(`${keys.CURRENTLY_DELIVERING}:${telegramId}`),
   getDriverCurrentDelivering: (telegramId: number): Promise<string[]> =>
     redis
       .get(`${keys.CURRENTLY_DELIVERING}:${telegramId}`)

--- a/packages/driver-interface/src/services/cache.ts
+++ b/packages/driver-interface/src/services/cache.ts
@@ -62,7 +62,8 @@ export default {
       .get(`${keys.INSTRUCTION_GROUPS}:${id}`)
       .del(`${keys.INSTRUCTION_GROUPS}:${id}`)
       .exec()
-      .then(([res]) => JSON.parse(res[1])),
+      .then(([res]) => JSON.parse(res[1]))
+      .then((res) => res || []),
 
   getInstructionGroup: (id: string): Promise<Instruction[]> =>
     redis

--- a/packages/driver-interface/src/services/cache.ts
+++ b/packages/driver-interface/src/services/cache.ts
@@ -8,6 +8,8 @@ const keys = {
   VEHICLES: 'vehicles',
   VEHICLE_ID_BY_TELEGRAM_ID: 'vehicle-id-by-telegram-id',
   VEHICLE_ID_BY_PHONE_NUMBER: 'vehicle-id-by-phone-nr',
+  CURRENTLY_DELIVERING: 'currently_delivering',
+  RECEIPT_PHOTOS: 'receipt_photos',
 }
 
 export default {
@@ -61,4 +63,35 @@ export default {
       .del(`${keys.INSTRUCTION_GROUPS}:${id}`)
       .exec()
       .then(([res]) => JSON.parse(res[1])),
+
+  getInstructionGroup: (id: string): Promise<Instruction[]> =>
+    redis
+      .get(`${keys.INSTRUCTION_GROUPS}:${id}`)
+      .then((res) => JSON.parse(res)),
+
+  setDriverCurrentlyDelivering: (
+    telegramId: number,
+    bookindIds: string[]
+  ): Promise<string> =>
+    redis.set(
+      `${keys.CURRENTLY_DELIVERING}:${telegramId}`,
+      JSON.stringify(bookindIds)
+    ),
+  getDriverCurrentDelivering: (telegramId: number): Promise<string[]> =>
+    redis
+      .get(`${keys.CURRENTLY_DELIVERING}:${telegramId}`)
+      .then((res) => JSON.parse(res)),
+  saveDeliveryReceiptPhoto: (
+    bookingIds: string[],
+    photoIds: string[]
+  ): Promise<string> =>
+    redis.set(
+      `${keys.RECEIPT_PHOTOS}:${bookingIds.join('-')}`,
+      JSON.stringify(photoIds)
+    ),
+  getDeliveryReceiptPhotos: (bookingIds: string[]): Promise<string[]> =>
+    redis
+      .get(`${keys.RECEIPT_PHOTOS}:${bookingIds.join('-')}`)
+      .then((res) => JSON.parse(res))
+      .then((list) => list || []),
 }

--- a/packages/driver-interface/src/services/messaging.ts
+++ b/packages/driver-interface/src/services/messaging.ts
@@ -270,7 +270,7 @@ export const sendDeliveryInformation = (
           : ''
       )
       .concat(
-        `\nTryck "[Levererat]" när du har lämnat ${
+        `\nTryck "[Kvittera Leverans]" för att påbörja kvittens av ${
           instructionGroup.length > 1 ? 'paketen' : 'paketet'
         }, eller "[Kunde inte leverera]" om du av någon anledning inte kunde leverera ${
           instructionGroup.length > 1 ? 'paketen' : 'paketet'
@@ -282,9 +282,9 @@ export const sendDeliveryInformation = (
         inline_keyboard: [
           [
             {
-              text: 'Levererat',
+              text: 'Kvittera leverans',
               callback_data: JSON.stringify({
-                e: 'delivered',
+                e: 'begin_delivery_acknowledgement',
                 id: instructionGroupId,
               }),
             },
@@ -302,3 +302,31 @@ export const sendDeliveryInformation = (
     }
   )
 }
+
+export const sendBeginDeliveryAcknowledgement = (telegramId: number) => {
+  bot.telegram.sendMessage(
+    telegramId,
+    'Fotografera nu mottagaren tillsammans med paketet och skicka'
+  )
+}
+
+export const sendPhotoReceived = (telegramId: number) =>
+  bot.telegram.sendMessage(
+    telegramId,
+    'Tack, ditt foto har sparats! Du kan ta fler foton om du vill eller tryck på Klar om du är färdig med leverans och kvittens.',
+    {
+      parse_mode: 'Markdown',
+      reply_markup: {
+        inline_keyboard: [
+          [
+            {
+              text: 'Klar',
+              callback_data: JSON.stringify({
+                e: 'delivered',
+              }),
+            },
+          ],
+        ],
+      },
+    }
+  )

--- a/packages/driver-interface/src/services/messaging.ts
+++ b/packages/driver-interface/src/services/messaging.ts
@@ -303,7 +303,7 @@ export const sendDeliveryInformation = (
   )
 }
 
-export const sendPhotoReceived = (telegramId: number) =>
+export const sendPhotoReceived = (telegramId: number): Promise<Message> =>
   bot.telegram.sendMessage(
     telegramId,
     `Tack, ditt foto har sparats!\nDu kan ta fler foton om du vill, tryck annars på _Klar_ om du är färdig med kvittensen.`,
@@ -323,9 +323,15 @@ export const sendPhotoReceived = (telegramId: number) =>
       },
     }
   )
-export const sendBeginDeliveryAcknowledgement = (telegramId: number) => {
+export const sendBeginDeliveryAcknowledgement = (
+  telegramId: number
+): Promise<Message> =>
   bot.telegram.sendMessage(
     telegramId,
     'Fotografera nu mottagaren tillsammans med paketet och skicka bilden här.'
   )
-}
+
+export const sendCouldNotSavePhoto = async (
+  telegramId: number
+): Promise<Message> =>
+  bot.telegram.sendMessage(telegramId, 'Kunde inte spara bilden på servern.')

--- a/packages/driver-interface/src/services/messaging.ts
+++ b/packages/driver-interface/src/services/messaging.ts
@@ -303,17 +303,10 @@ export const sendDeliveryInformation = (
   )
 }
 
-export const sendBeginDeliveryAcknowledgement = (telegramId: number) => {
-  bot.telegram.sendMessage(
-    telegramId,
-    'Fotografera nu mottagaren tillsammans med paketet och skicka'
-  )
-}
-
 export const sendPhotoReceived = (telegramId: number) =>
   bot.telegram.sendMessage(
     telegramId,
-    'Tack, ditt foto har sparats! Du kan ta fler foton om du vill eller tryck på Klar om du är färdig med leverans och kvittens.',
+    `Tack, ditt foto har sparats!\nDu kan ta fler foton om du vill, tryck annars på _Klar_ om du är färdig med kvittensen.`,
     {
       parse_mode: 'Markdown',
       reply_markup: {
@@ -330,3 +323,9 @@ export const sendPhotoReceived = (telegramId: number) =>
       },
     }
   )
+export const sendBeginDeliveryAcknowledgement = (telegramId: number) => {
+  bot.telegram.sendMessage(
+    telegramId,
+    'Fotografera nu mottagaren tillsammans med paketet och skicka bilden här.'
+  )
+}


### PR DESCRIPTION
This PR lets a user upon delivering a package; send back a photo of the delivery. The photo is saved as a Telegram photo ID in redis. Can later be retreived with
`https://api.telegram.org/bot<botToken>/getFile?file_id=<insert the ID here>`

Which will generate a file_path which can be used like:
`https://api.telegram.org/file/bot<botToken>/<insert file_path here>`