### PR TITLE
fix: replace deprecated actions/setup-elixir with erlef/setup-elixir

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
           RABBITMQ_PORT: "5672"
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-elixir@v1.0.0
+      - uses: erlef/setup-elixir@v1.6.0
         with:
           otp-version: "23.1"
           elixir-version: "1.11.1"


### PR DESCRIPTION
[actions/setup-elixir](https://github.com/actions/setup-elixir) by Github is no longer maintained. Project is forked as [erlef/setup-elixir](https://github.com/erlef/setup-elixir) and maintained by The Erlang Ecosystem Foundation.

This fixes this error we had:
```
Run actions/setup-elixir@v1.0.0
Installing OTP 23.1
  /home/runner/work/_actions/actions/setup-elixir/v1.0.0/src/install-otp-ubuntu 23.1
  Reading package lists...
  Building dependency tree...
  Reading state information...
  libwxbase3.0-0v5 is already the newest version (3.0.4+dfsg-15build1).
  libwxbase3.0-0v5 set to manually installed.
  0 upgraded, 0 newly installed, 0 to remove and 4 not upgraded.
  Reading package lists...
  Building dependency tree...
  Reading state information...
  Package libwxgtk3.0-0v5 is not available, but is referred to by another package.
  This may mean that the package is missing, has been obsoleted, or
  is only available from another source
  
  E: Package 'libwxgtk3.0-0v5' has no installation candidate
  Error: The process '/home/runner/work/_actions/actions/setup-elixir/v1.0.0/src/install-otp-ubuntu' failed with exit code 100
  ```