### PR TITLE
chore: implement focus point to pelias query

### DIFF
--- a/packages/engine-ui/src/hooks/useGetSuggestedAddresses.ts
+++ b/packages/engine-ui/src/hooks/useGetSuggestedAddresses.ts
@@ -1,11 +1,14 @@
 import React from 'react'
 import * as helpers from '../utils/helpers'
+import * as stores from '../utils/state/stores'
 
 const useGetSuggestedAddresses = (initialState = []) => {
   const [suggested, set] = React.useState(initialState)
+  const viewState = stores.map((state) => state)
+
   const find = (query: string, callback: () => void) =>
     helpers
-      .findAddress(query)
+      .findAddress(query, viewState)
       .then(({ features }) => {
         const parsedFeatures = features.map(
           ({

--- a/packages/engine-ui/src/utils/helpers.ts
+++ b/packages/engine-ui/src/utils/helpers.ts
@@ -1,5 +1,5 @@
 import moment from 'moment'
-
+import { MapState } from '../types/state'
 interface Feature {
   properties: {
     label: string
@@ -8,12 +8,13 @@ interface Feature {
   }
 }
 
-const findAddress = (query: string) => {
+const findAddress = (query: string, focusPoint: MapState) => {
   if (!query) {
     return Promise.resolve({ features: [] })
   }
+
   return fetch(
-    `https://pelias.iteamdev.io/v1/autocomplete?layers=address&boundary.country=se&text=${query}`,
+    `https://pelias.iteamdev.io/v1/autocomplete?layers=address&boundary.country=se&text=${query}&focus.point.lat=${focusPoint.latitude}&focus.point.lon=${focusPoint.longitude}`,
     {
       headers: {
         'Accept-Language': 'sv-SE',


### PR DESCRIPTION
When searching for address we now get the closets matches from where the map is displayed. 