### PR TITLE
fix: 🐛 event listeners warning

### DIFF
--- a/packages/engine-server/lib/engineConnector.js
+++ b/packages/engine-server/lib/engineConnector.js
@@ -24,7 +24,10 @@ const routingKeys = {
 const JUST_DO_IT_MESSAGE = 'JUST DO IT.'
 
 module.exports = (io) => {
-  amqp.connect().then((amqpConnection) => amqpConnection.createChannel())
+  amqp.connect().then((amqpConnection) => {
+    amqpConnection.setMaxListeners(30)
+    return amqpConnection.createChannel()
+  })
 
   /////// Listeners
 

--- a/packages/engine-server/lib/index.js
+++ b/packages/engine-server/lib/index.js
@@ -1,6 +1,5 @@
 const server = require('http').createServer()
 const io = require('socket.io')(server)
-require('events').defaultMaxListeners = 25
 require('./cache')
 
 const port = 4000


### PR DESCRIPTION
we should change the limit only for amqp and not set it globally