### PR TITLE
fix: rabbitmq reconnect 

### DIFF
--- a/packages/auto-accept-offer/amqp.js
+++ b/packages/auto-accept-offer/amqp.js
@@ -1,11 +1,41 @@
-const open = require('amqplib').connect(
-  process.env.AMQP_URL || 'amqp://localhost'
-)
+const { connect } = require('amqplib')
+const amqpTimeout = parseInt(process.env.AMQP_RECONNECT_TIMEOUT, 10) || 5000
+
+function connectRabbit() {
+  const connection = connect(process.env.AMQP_URL || 'amqp://localhost')
+
+  connection
+    .then((connection) => {
+      connection.on('error', (err) => {
+        console.error(err)
+        setTimeout(() => {
+          open = connectRabbit()
+        }, amqpTimeout)
+      })
+
+      connection.on('close', (err) => {
+        console.error(err)
+        setTimeout(() => {
+          open = connectRabbit()
+        }, amqpTimeout)
+      })
+    })
+    .catch((err) => {
+      console.error(err)
+      setTimeout(() => {
+        open = connectRabbit()
+      }, amqpTimeout)
+    })
+
+  return connection
+}
+
+let open = connectRabbit()
 
 const exchanges = {}
 
 const queues = {
-  PICKUP_OFFERS: 'auto_accept_pickup_offers'
+  PICKUP_OFFERS: 'auto_accept_pickup_offers',
 }
 
 module.exports = {

--- a/packages/auto-accept-offer/package-lock.json
+++ b/packages/auto-accept-offer/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "vehicle-accept-offer",
+  "name": "auto-accept-offer",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/packages/driver-interface/src/adapters/amqp.ts
+++ b/packages/driver-interface/src/adapters/amqp.ts
@@ -1,6 +1,37 @@
 import { connect } from 'amqplib'
 
-export const open = connect(process.env.AMQP_URL || 'amqp://localhost')
+const amqpTimeout = parseInt(process.env.AMQP_RECONNECT_TIMEOUT, 10) || 5000
+
+export let open = connectRabbit()
+
+function connectRabbit() {
+  const connection = connect(process.env.AMQP_URL || 'amqp://localhost')
+
+  connection
+    .then((connection) => {
+      connection.on('error', (err) => {
+        console.error(err)
+        setTimeout(() => {
+          open = connectRabbit()
+        }, amqpTimeout)
+      })
+
+      connection.on('close', (err) => {
+        console.error(err)
+        setTimeout(() => {
+          open = connectRabbit()
+        }, amqpTimeout)
+      })
+    })
+    .catch((err) => {
+      console.error(err)
+      setTimeout(() => {
+        open = connectRabbit()
+      }, amqpTimeout)
+    })
+
+  return connection
+}
 
 export const exchanges = {
   INCOMING_BOOKING_UPDATES: 'incoming_booking_updates',

--- a/packages/vehicle-offer/amqp.js
+++ b/packages/vehicle-offer/amqp.js
@@ -1,13 +1,43 @@
-const open = require('amqplib').connect(
-  process.env.AMQP_URL || 'amqp://localhost'
-)
+const { connect } = require('amqplib')
+const amqpTimeout = parseInt(process.env.AMQP_RECONNECT_TIMEOUT, 10) || 5000
+
+function connectRabbit() {
+  const connection = connect(process.env.AMQP_URL || 'amqp://localhost')
+
+  connection
+    .then((connection) => {
+      connection.on('error', (err) => {
+        console.error(err)
+        setTimeout(() => {
+          open = connectRabbit()
+        }, amqpTimeout)
+      })
+
+      connection.on('close', (err) => {
+        console.error(err)
+        setTimeout(() => {
+          open = connectRabbit()
+        }, amqpTimeout)
+      })
+    })
+    .catch((err) => {
+      console.error(err)
+      setTimeout(() => {
+        open = connectRabbit()
+      }, amqpTimeout)
+    })
+
+  return connection
+}
+
+let open = connectRabbit()
 
 const exchanges = {}
 
 const queues = {
   OFFER_BOOKING_TO_VEHICLE: 'offer_booking_to_vehicle',
   OFFER_BOOKING_TO_TELEGRAM_VEHICLE: 'offer_bookings_to_telegram_vehicles',
-  AUTO_ACCEPT_OFFERS: 'auto_accept_pickup_offers'
+  AUTO_ACCEPT_OFFERS: 'auto_accept_pickup_offers',
 }
 
 module.exports = {


### PR DESCRIPTION
This adds reconnect to rabbitmq that would otherwise just crash the following packages:
- driver-interface
- auto-accept-offer
- vehicle-offer

### How to test:

Scenarios tested:
- rabbitmq is not available on startup of applications but then becomes available ( easier to test by running any of the services below local )
- rabbitmq becomes unavailable for a period of time ( `docker stop` and `docker start`)

---

#### driver-interface:

Have tested both running in Docker or locally, if you run it in Docker make sure to run `docker-compose build` and have `TELEGRAM_BOT_TOKEN` env variable set

#### auto-accept-offer & vehicle-offer

Have tested both running in Docker or locally, if you run it in Docker make sure to run `docker-compose build`