### PR TITLE
fix: 🐛 access to k8s cluster from github

### DIFF
--- a/k8s/config.yaml
+++ b/k8s/config.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 clusters:
   - cluster:
-      certificate-authority-data: $KUBE_CLUSTER_CERTIFICATE
       server: $KUBE_CLUSTER_SERVER
+      insecure-skip-tls-verify: true
     name: $KUBE_CLUSTER_NAME
 contexts:
   - context:


### PR DESCRIPTION
The error we get for the certificate used to connect to the cluster is `Unable to connect to the server: x509: certificate is valid for 127.0.0.1, ...` which blocks our deploy pipeline.

Not using the certificate and adding `--insecure-skip-tls-verify` seems to solve this but I don't understand the implications. 

Material used to understand what the flag implies:
- https://kubernetes.io/docs/reference/kubectl/kubectl/
- https://serverfault.com/questions/1045697/how-to-disable-kubectl-insecure-approval-towards-the-kube-apiserver
