### PR TITLE
chore: hide notifications in mobile view

### DIFF
--- a/packages/engine-ui/src/components/Sidebar.tsx
+++ b/packages/engine-ui/src/components/Sidebar.tsx
@@ -38,7 +38,7 @@ interface Props {
 const Sidebar = (state: Props) => {
   return (
     <>
-      <Notifications />
+      {!state.isMobile && <Notifications />}
       <Container>
         <Navigation />
         <Content isMobile={state.isMobile}>


### PR DESCRIPTION
How to test: 
Create a booking/transport in a mobile view and see no notification. 
Create a booking/transport in desktop view and see a notification 
