### PR TITLE
fix: 🐛 reconnect rabbitmq in vehicle-offer & auto-accept-offer

### DIFF
--- a/packages/auto-accept-offer/amqp.js
+++ b/packages/auto-accept-offer/amqp.js
@@ -1,7 +1,7 @@
 const { connect } = require('amqplib')
 const amqpTimeout = parseInt(process.env.AMQP_RECONNECT_TIMEOUT, 10) || 5000
 
-function connectRabbit() {
+function connectRabbit(callback) {
   const connection = connect(process.env.AMQP_URL || 'amqp://localhost')
 
   connection
@@ -9,28 +9,28 @@ function connectRabbit() {
       connection.on('error', (err) => {
         console.error(err)
         setTimeout(() => {
-          open = connectRabbit()
+          connectRabbit(callback)
         }, amqpTimeout)
       })
 
       connection.on('close', (err) => {
         console.error(err)
         setTimeout(() => {
-          open = connectRabbit()
+          connectRabbit(callback)
         }, amqpTimeout)
       })
+
+      console.info('=> Connected to RabbitMQ')
+
+      callback(connection)
     })
     .catch((err) => {
       console.error(err)
       setTimeout(() => {
-        open = connectRabbit()
+        connectRabbit(callback)
       }, amqpTimeout)
     })
-
-  return connection
 }
-
-let open = connectRabbit()
 
 const exchanges = {}
 
@@ -39,7 +39,7 @@ const queues = {
 }
 
 module.exports = {
-  open,
+  connect: connectRabbit,
   queues,
   exchanges,
 }

--- a/packages/auto-accept-offer/index.js
+++ b/packages/auto-accept-offer/index.js
@@ -1,34 +1,30 @@
-const {
-  open,
-  queues
-} = require('./amqp')
+const { connect, queues } = require('./amqp')
 
-open
-  .then((conn) => conn.createChannel())
-  .then((ch) =>
+function setupListeners(connection) {
+  connection.createChannel().then((ch) =>
     ch
-    .assertQueue(queues.PICKUP_OFFERS, {
-      durable: false,
-    })
-    .then(() =>
-      ch.consume(queues.PICKUP_OFFERS, async (message) => {
-        const {
-          replyTo,
-          correlationId
-        } = message.properties
-
-        console.log('accepting the offer now')
-
-        try {
-          ch.sendToQueue(replyTo, Buffer.from(JSON.stringify(true)), {
-            correlationId,
-          })
-
-          ch.ack(message)
-        } catch (error) {
-          console.warn('something borked: ', error)
-        }
+      .assertQueue(queues.PICKUP_OFFERS, {
+        durable: false,
       })
-    )
-    .catch(console.warn)
+      .then(() =>
+        ch.consume(queues.PICKUP_OFFERS, async (message) => {
+          const { replyTo, correlationId } = message.properties
+
+          console.log('accepting the offer now')
+
+          try {
+            ch.sendToQueue(replyTo, Buffer.from(JSON.stringify(true)), {
+              correlationId,
+            })
+
+            ch.ack(message)
+          } catch (error) {
+            console.warn('something borked: ', error)
+          }
+        })
+      )
+      .catch(console.warn)
   )
+}
+
+connect(setupListeners)

--- a/packages/vehicle-offer/amqp.js
+++ b/packages/vehicle-offer/amqp.js
@@ -1,7 +1,7 @@
 const { connect } = require('amqplib')
 const amqpTimeout = parseInt(process.env.AMQP_RECONNECT_TIMEOUT, 10) || 5000
 
-function connectRabbit() {
+function connectRabbit(callback) {
   const connection = connect(process.env.AMQP_URL || 'amqp://localhost')
 
   connection
@@ -9,28 +9,28 @@ function connectRabbit() {
       connection.on('error', (err) => {
         console.error(err)
         setTimeout(() => {
-          open = connectRabbit()
+          connectRabbit(callback)
         }, amqpTimeout)
       })
 
       connection.on('close', (err) => {
         console.error(err)
         setTimeout(() => {
-          open = connectRabbit()
+          connectRabbit(callback)
         }, amqpTimeout)
       })
+
+      console.info('=> Connected to RabbitMQ')
+
+      callback(connection)
     })
     .catch((err) => {
       console.error(err)
       setTimeout(() => {
-        open = connectRabbit()
+        connectRabbit(callback)
       }, amqpTimeout)
     })
-
-  return connection
 }
-
-let open = connectRabbit()
 
 const exchanges = {}
 
@@ -41,7 +41,7 @@ const queues = {
 }
 
 module.exports = {
-  open,
+  connect: connectRabbit,
   queues,
   exchanges,
 }

--- a/packages/vehicle-offer/index.js
+++ b/packages/vehicle-offer/index.js
@@ -1,11 +1,12 @@
-const { open, queues } = require('./amqp')
+const { connect, queues } = require('./amqp')
 console.log('Sending telegram offers to ', queues.TELEGRAM_OFFERS)
 console.log('Sending generated offers to ', queues.AUTO_ACCEPT_OFFERS)
 console.log(Object.values(queues))
-open
-  .then((conn) => conn.createChannel())
-  .then((ch) =>
-    Promise.all(
+
+function setupListeners(connection) {
+  connection.createChannel().then((ch) => {
+    console.log('==> Channel was created')
+    return Promise.all(
       Object.values(queues).map((queue) =>
         ch.assertQueue(queue, {
           durable: false,
@@ -15,13 +16,20 @@ open
       .then(() =>
         ch.consume(queues.OFFER_BOOKING_TO_VEHICLE, async (message) => {
           const { vehicle } = JSON.parse(message.content.toString())
- 
-          console.log("Received pickup offer to:", vehicle)
 
-          ch.sendToQueue(queues.AUTO_ACCEPT_OFFERS, message.content, message.properties)
+          console.log('Received pickup offer to:', vehicle)
+
+          ch.sendToQueue(
+            queues.AUTO_ACCEPT_OFFERS,
+            message.content,
+            message.properties
+          )
 
           ch.ack(message)
         })
       )
       .catch(console.warn)
-  )
+  })
+}
+
+connect(setupListeners)


### PR DESCRIPTION
This fixes an issue with `vehicle-offer` and `auto-accept-offer` packages where even though they reconnect to rabbitmq on error, our code for adding queue listeners doesn't run anymore which causes them to not receive messages and thus causing problems with confirming plan flow.

Made it so that we pass the queues listener setup as a callback to connect function that handles reconnecting and will invoke this setup on reconnect.

### How to test

First to reproduce the bug you can test it on `master` branch and it sometimes happens when you run `docker-compose up` due to rabbitmq not being ready to accept connections. 
A more reliable method is to comment out one of this packages from the `docker-compose` file and make sure nothing is running in Docker. Then start the service locally and then run `docker-compose up`. You will see that confirming the plan will show an error in the engine.

Then try it on this branch and this should not happen anymore.