### PR TITLE
Compose use files from disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To debug run:
 
     skaffold dev
 
-### Before you start running the project
+#### Before you start running the project
 
 Start by exporting port 9200
 
@@ -68,43 +68,23 @@ POSTNORD_KEY - for engine-server
 REACT_APP_MAPBOX_ACCESS_TOKEN - for engine-ui
 GOOGLE_API_TOKEN - for driver-interface
 TELEGRAM_BOT_TOKEN - for driver-interface
-TELEGRAM_BOOKING_TOKEN - for booking interface
 
-#### Via docker-compose:
-
-Set project build variables
-
-    export REACT_APP_MAPBOX_ACCESS_TOKEN=<FROM LASTPASS>
-
-Set project env variables
-
-    export GOOGLE_API_TOKEN=<FROM LASTPASS>
-    export TELEGRAM_BOT_TOKEN=<FROM LASTPASS> / create your own from telegram
-    export TELEGRAM_BOOKING_TOKEN=<FROM LASTPASS> / create your own from telegram
-    export POSTNORD_KEY=<FROM LASTPASS>
-
-Start dependencies
-
-    docker-compose up -d
-
-#### Locally (outside of docker):
+#### Set environment variables
 
 create .env-file in packages/driver-interface/.env with
 
     GOOGLE_API_TOKEN=<FROM LASTPASS>
-    BOT_TOKEN=<FROM LASTPASS> / create your own from telegram
+    BOT_TOKEN=<FROM LASTPASS> / or create your own bot in telegram
 
 create .env-file in packages/engine-ui/.env with
 
     REACT_APP_MAPBOX_ACCESS_TOKEN=<FROM LASTPASS>
 
-create .env-file in packages/booking-interface/.env with
+#### Start the services
 
-    BOT_TOKEN=<FROM LASTPASS>
+    docker-compose up
 
-Go into every folder and run the start command for the service.
-
-#### run event_store migrations and start the engine
+#### Run migrations and start the engine
 
     cd packages/engine_umbrella/
     mix deps.get

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,14 +113,6 @@ services:
       - AMQP_URL=amqp://rabbitmq
     networks:
       - predictivemovement
-  booking-dispatcher:
-    build: ./packages/booking-dispatcher
-    environment:
-      - AMQP_URL=amqp://rabbitmq
-    volumes:
-      - ./packages/booking-dispatcher/data:/app/data
-    networks:
-      - predictivemovement
   storage:
     image: minio/minio
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,12 @@ services:
     networks:
       - predictivemovement
   admin-server:
-    build: ./packages/engine-server
+    image: node:14.9-slim
+    volumes:
+      - type: bind
+        source: ./packages/engine-server
+        target: /app
+    command: sh -c 'cd /app && npm ci && npm run dev'
     environment:
       - AMQP_URL=amqp://rabbitmq
       - POSTNORD_KEY=${POSTNORD_KEY}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,13 +27,17 @@ services:
     networks:
       - predictivemovement
   admin-ui:
-    build:
-      context: ./packages/engine-ui
-      args:
-        - REACT_APP_MAPBOX_ACCESS_TOKEN=${REACT_APP_MAPBOX_ACCESS_TOKEN}
-        - REACT_APP_ENGINE_SERVER=http://localhost:4000
+    image: node:14.9-slim
+    volumes:
+      - type: bind
+        source: ./packages/engine-ui
+        target: /app
+    command: sh -c 'cd /app && npm ci && npm start'
+    environment:
+      - REACT_APP_MAPBOX_ACCESS_TOKEN=${REACT_APP_MAPBOX_ACCESS_TOKEN}
+      - REACT_APP_ENGINE_SERVER=http://localhost:4000
     ports:
-      - 127.0.0.1:3000:80
+      - 127.0.0.1:3000:3000
     networks:
       - predictivemovement
   admin-server:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,6 @@ services:
         target: /app
     command: sh -c 'cd /app && npm ci --quiet && npm start'
     environment:
-      - REACT_APP_MAPBOX_ACCESS_TOKEN=${REACT_APP_MAPBOX_ACCESS_TOKEN}
       - REACT_APP_ENGINE_SERVER=http://localhost:4000
     ports:
       - 127.0.0.1:3000:3000
@@ -49,7 +48,6 @@ services:
     command: sh -c 'cd /app && npm ci --quiet && npm run dev'
     environment:
       - AMQP_URL=amqp://rabbitmq
-      - POSTNORD_KEY=${POSTNORD_KEY}
       - MINIO_HOST=storage
     ports:
       - 127.0.0.1:4000:4000
@@ -74,10 +72,8 @@ services:
       - type: bind
         source: ./packages/driver-interface
         target: /app
-    command: sh -c 'cd /app && npm ci --quiet && npm start'
+    command: sh -c 'cd /app && npm ci --quiet && npm run dev'
     environment:
-      - BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
-      - GOOGLE_API_TOKEN=${GOOGLE_API_TOKEN}
       - AMQP_HOST=rabbitmq
       - AMQP_URL=amqp://rabbitmq
       - REDIS_URL=redis://redis:6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - type: bind
         source: ./packages/engine-ui
         target: /app
-    command: sh -c 'cd /app && npm ci && npm start'
+    command: sh -c 'cd /app && npm ci --quiet && npm start'
     environment:
       - REACT_APP_MAPBOX_ACCESS_TOKEN=${REACT_APP_MAPBOX_ACCESS_TOKEN}
       - REACT_APP_ENGINE_SERVER=http://localhost:4000
@@ -46,7 +46,7 @@ services:
       - type: bind
         source: ./packages/engine-server
         target: /app
-    command: sh -c 'cd /app && npm ci && npm run dev'
+    command: sh -c 'cd /app && npm ci --quiet && npm run dev'
     environment:
       - AMQP_URL=amqp://rabbitmq
       - POSTNORD_KEY=${POSTNORD_KEY}
@@ -61,7 +61,7 @@ services:
       - type: bind
         source: ./packages/signing-ui
         target: /app
-    command: sh -c 'cd /app && npm ci && npm start'
+    command: sh -c 'cd /app && npm ci --quiet && npm start'
     environment:
       - REACT_APP_ENGINE_SERVER=http://localhost:4000
     ports:
@@ -74,7 +74,7 @@ services:
       - type: bind
         source: ./packages/driver-interface
         target: /app
-    command: sh -c 'cd /app && npm ci && npm start'
+    command: sh -c 'cd /app && npm ci --quiet && npm start'
     environment:
       - BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
       - GOOGLE_API_TOKEN=${GOOGLE_API_TOKEN}
@@ -97,7 +97,7 @@ services:
       - type: bind
         source: ./packages/vehicle-offer
         target: /app
-    command: sh -c 'cd /app && npm ci && npm start'
+    command: sh -c 'cd /app && npm ci --quiet && npm start'
     environment:
       - AMQP_URL=amqp://rabbitmq
     networks:
@@ -108,7 +108,7 @@ services:
       - type: bind
         source: ./packages/auto-accept-offer
         target: /app
-    command: sh -c 'cd /app && npm ci && npm start'
+    command: sh -c 'cd /app && npm ci --quiet && npm start'
     environment:
       - AMQP_URL=amqp://rabbitmq
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,13 +122,6 @@ services:
       - ./data:/data
     networks:
       - predictivemovement
-  extract-text-from-pic:
-    build: ./packages/extract-text-from-pic
-    ports:
-      - 127.0.0.1:4001:4000
-    networks:
-      - predictivemovement
-
 networks:
   predictivemovement:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,32 +56,31 @@ services:
     networks:
       - predictivemovement
   signing-ui:
-    build:
-      context: ./packages/signing-ui
-      args:
-        - REACT_APP_ENGINE_SERVER=http://localhost:4000
+    image: node:14.9-slim
+    volumes:
+      - type: bind
+        source: ./packages/signing-ui
+        target: /app
+    command: sh -c 'cd /app && npm ci && npm start'
+    environment:
+      - REACT_APP_ENGINE_SERVER=http://localhost:4000
     ports:
-      - 127.0.0.1:3001:80
+      - 127.0.0.1:3001:3001
     networks:
       - predictivemovement
   driver-interface:
-    build: ./packages/driver-interface
+    image: node:14.9-slim
+    volumes:
+      - type: bind
+        source: ./packages/driver-interface
+        target: /app
+    command: sh -c 'cd /app && npm ci && npm start'
     environment:
       - BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
       - GOOGLE_API_TOKEN=${GOOGLE_API_TOKEN}
       - AMQP_HOST=rabbitmq
       - AMQP_URL=amqp://rabbitmq
       - REDIS_URL=redis://redis:6379
-    networks:
-      - predictivemovement
-  booking-interface:
-    build: ./packages/booking-interface
-    environment:
-      - BOT_TOKEN=${TELEGRAM_BOOKING_TOKEN}
-      - EXTRACT_TEXT_FROM_PIC_URL=http://extract-text-from-pic:4000
-      - AMQP_HOST=rabbitmq
-      - AMQP_URL=amqp://rabbitmq
-      - ELASTICSEARCH_URL=${PELIAS_ELASTICSEARCH_URL:-http://host.docker.internal:9200}
     networks:
       - predictivemovement
   predictivemovement-route-optimization-jsprit:
@@ -93,13 +92,23 @@ services:
     networks:
       - predictivemovement
   vehicle-offer-router:
-    build: ./packages/vehicle-offer
+    image: node:14.9-slim
+    volumes:
+      - type: bind
+        source: ./packages/vehicle-offer
+        target: /app
+    command: sh -c 'cd /app && npm ci && npm start'
     environment:
       - AMQP_URL=amqp://rabbitmq
     networks:
       - predictivemovement
   auto-accept-offer:
-    build: ./packages/auto-accept-offer
+    image: node:14.9-slim
+    volumes:
+      - type: bind
+        source: ./packages/auto-accept-offer
+        target: /app
+    command: sh -c 'cd /app && npm ci && npm start'
     environment:
       - AMQP_URL=amqp://rabbitmq
     networks:

--- a/packages/engine_umbrella/apps/engine/mix_tasks/create_test_database.ex
+++ b/packages/engine_umbrella/apps/engine/mix_tasks/create_test_database.ex
@@ -8,10 +8,10 @@ defmodule Mix.Tasks.SetupTestDatabase do
 
     config = [
       serializer: Engine.JsonSerializer,
-      username: "postgres",
-      password: "postgres",
-      database: "eventstore",
-      hostname: "localhost",
+      username: System.get_env("POSTGRES_USER") || "postgres",
+      password: System.get_env("POSTGRES_PASSWORD") || "postgres",
+      database: System.get_env("POSTGRES_DB") || "eventstore",
+      hostname: System.get_env("POSTGRES_HOST") || "localhost",
       schema: "test"
     ]
 

--- a/packages/engine_umbrella/config/config.exs
+++ b/packages/engine_umbrella/config/config.exs
@@ -13,9 +13,9 @@ config :engine, event_stores: [Engine.ES]
 
 config :engine, Engine.ES,
   serializer: Engine.JsonSerializer,
-  username: "postgres",
-  password: "postgres",
-  database: "eventstore",
-  hostname: "localhost"
+  username: System.get_env("POSTGRES_USER") || "postgres",
+  password: System.get_env("POSTGRES_PASSWORD") || "postgres",
+  database: System.get_env("POSTGRES_DB") || "eventstore",
+  hostname: System.get_env("POSTGRES_HOST") || "localhost"
 
 if Mix.env() == :test, do: import_config("test.exs")


### PR DESCRIPTION
Make docker compose use files from disk instead of building an image. This way you don't have to build a new image to test changes. You also don't have to export environment variables to get them into the image, instead each service will use its .env-file.