### PR TITLE
fix: just update current position in create not in edit

### DIFF
--- a/packages/engine-ui/src/components/forms/CreateBooking.tsx
+++ b/packages/engine-ui/src/components/forms/CreateBooking.tsx
@@ -60,11 +60,12 @@ const Component = ({
 
   React.useEffect(() => {
     if (currentLocation.lat || currentLocation.lon) {
-      setFieldValue('pickup', {
-        ...currentLocation,
-        name: `${currentLocation.name}, ${currentLocation.county}`,
-        street: currentLocation.name,
-      })
+      type === 'NEW' &&
+        setFieldValue('pickup', {
+          ...currentLocation,
+          name: `${currentLocation.name}, ${currentLocation.county}`,
+          street: currentLocation.name,
+        })
     }
   }, [currentLocation])
 


### PR DESCRIPTION
### Problem
The time window was reset when going into edit for a booking with time windows. 
### Reason
The current position updated from the edit view and by doing that the time windows got removed. 

### Solution 
Just use the current position while creating a booking. 