### PR TITLE
feat: send driver dates in UTC

### DIFF
--- a/packages/engine-ui/src/components/CreateTransport.tsx
+++ b/packages/engine-ui/src/components/CreateTransport.tsx
@@ -3,10 +3,10 @@ import * as Elements from '../shared-elements'
 import Form from './forms/CreateTransport'
 import MainRouteLayout from './layout/MainRouteLayout'
 import Success from './SuccessScreen'
-import moment from 'moment'
 import * as stores from '../utils/state/stores'
 import React from 'react'
 import { Formik, FormikHelpers } from 'formik'
+import { formatLocalToUTC } from '../utils/helpers'
 
 export const transportPresets = {
   small: { weight: '1234', volume: '18' },
@@ -93,14 +93,14 @@ const CreateTransport = ({
     onSubmit({
       ...values,
       earliestStart: values.earliestStart
-        ? moment(values.earliestStart).format('HH:mm')
+        ? formatLocalToUTC(values.earliestStart).format('HH:mm')
         : values.earliestStart,
       capacity: {
         weight: parseInt(values.capacity.weight),
         volume: parseFloat(values.capacity.volume),
       },
       latestEnd: values.latestEnd
-        ? moment(values.latestEnd).format('HH:mm')
+        ? formatLocalToUTC(values.latestEnd).format('HH:mm')
         : values.latestEnd,
       startAddress: {
         ...values.startAddress,

--- a/packages/engine-ui/src/components/EditTransport/EditTransport.tsx
+++ b/packages/engine-ui/src/components/EditTransport/EditTransport.tsx
@@ -5,6 +5,7 @@ import Form from '../forms/CreateTransport'
 import moment from 'moment'
 import { transportPresets } from '../CreateTransport'
 import { Formik, FormikHelpers } from 'formik'
+import { formatLocalToUTC } from '../../utils/helpers'
 
 export interface FormState {
   capacity: {
@@ -71,14 +72,14 @@ const EditTransport = ({
     const updatedTransport = {
       ...values,
       earliestStart: values.earliestStart
-        ? moment(values.earliestStart).format('HH:mm')
+        ? formatLocalToUTC(values.earliestStart).format('HH:mm')
         : values.earliestStart,
       capacity: {
         weight: parseInt(values.capacity.weight),
         volume: parseFloat(values.capacity.volume),
       },
       latestEnd: values.latestEnd
-        ? moment(values.latestEnd).format('HH:mm')
+        ? formatLocalToUTC(values.latestEnd).format('HH:mm')
         : values.latestEnd,
       startAddress: {
         ...values.startAddress,

--- a/packages/engine-ui/src/components/EditTransport/index.tsx
+++ b/packages/engine-ui/src/components/EditTransport/index.tsx
@@ -5,8 +5,7 @@ import { Transport } from '../../types'
 import { useHistory, useParams } from 'react-router-dom'
 import EditTransport from './EditTransport'
 import Success from '../SuccessScreen'
-import { getAddressFromCoordinate } from '../../utils/helpers'
-import moment from 'moment'
+import { getAddressFromCoordinate, formatUTCtoLocal } from '../../utils/helpers'
 
 interface Props {
   transports: Transport[]
@@ -80,10 +79,10 @@ const EditTransportRoute = ({ transports, updateTransport }: Props) => {
             ...transport,
             earliestStart:
               transport.earliestStart &&
-              moment(transport.earliestStart, 'HH:mm').toDate(),
+              formatUTCtoLocal(transport.earliestStart).toDate(),
             latestEnd:
               transport.latestEnd &&
-              moment(transport.latestEnd, 'HH:mm').toDate(),
+              formatUTCtoLocal(transport.latestEnd).toDate(),
             capacity: {
               weight: transport.capacity?.weight?.toString() || '',
               volume: transport.capacity?.volume.toString() || '',

--- a/packages/engine-ui/src/components/TransportDetails.tsx
+++ b/packages/engine-ui/src/components/TransportDetails.tsx
@@ -9,6 +9,7 @@ import * as Icons from '../assets/Icons'
 import { FlyToInterpolator } from 'react-map-gl'
 import * as stores from '../utils/state/stores'
 import * as helpers from '../utils/helpers'
+import { formatUTCtoLocal } from '../utils/helpers'
 
 const Line = styled.div`
   border-top: 1px solid #dedede;
@@ -135,7 +136,8 @@ const TransportDetails: React.FC<{
         </Elements.Typography.StrongParagraph>
         <Elements.Layout.FlexRowWrapper>
           <Paragraph>
-            {transport.earliestStart} - {transport.latestEnd}
+            {formatUTCtoLocal(transport.earliestStart).format('HH:mm')} -{' '}
+            {formatUTCtoLocal(transport.latestEnd).format('HH:mm')}
           </Paragraph>
         </Elements.Layout.FlexRowWrapper>
         {transport.endAddress.name && (

--- a/packages/engine-ui/src/utils/helpers.ts
+++ b/packages/engine-ui/src/utils/helpers.ts
@@ -138,6 +138,14 @@ const shareCurrentLocation = (
   )
 }
 
+const formatUTCtoLocal = (utcTime: Date) => {
+  return moment.utc(utcTime, 'HH:mm').local()
+}
+
+const formatLocalToUTC = (localTime: Date) => {
+  return moment(localTime).utc()
+}
+
 export {
   findAddress,
   calculateMinTime,
@@ -151,4 +159,6 @@ export {
   getDistance,
   getDuration,
   shareCurrentLocation,
+  formatUTCtoLocal,
+  formatLocalToUTC,
 }


### PR DESCRIPTION
and display them in local format

Co-authored-by: Izabella Larsson <izabellalarsson@users.noreply.github.com>

### What it fixes and how to test:

It fixes (together with a change in the route-optimization package) an issue where even though the driver schedule should not allow them to be able to pickup and deliver a booking, a route can in some cases still be created and assigned to them.

The issue can be replicated on the `master` branch with the following input data that should not produce a plan (one should try to use fairly close locations so that driving time is not an issue):

```
transport schedule: 8 - 9

booking:
pickup: 9:30 - 13:30
delivery: 10:30 - 11:30
```

This fix will only work in conjunction with a change in the route-optimization package, so make sure [this PR](https://github.com/Iteam1337/predictivemovement/pull/392) is merged and included in this branch and remember to run `docker-compose build` before running the stack.

If that is not the case, you can checkout first the branch in :point_up: PR, run `docker-compose build` and then checkout this branch again and run `docker-compose up` (without the `build` step on this PR's branch as that would rebuild the route-optimization package from this branch)
