### PR TITLE
chore: remove extract-text-from-pic from compose again

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,12 +118,6 @@ services:
       - ./data:/data
     networks:
       - predictivemovement
-  extract-text-from-pic:
-    build: ./packages/extract-text-from-pic
-    ports:
-      - 127.0.0.1:4001:4000
-    networks:
-      - predictivemovement
   api:
     build: ./packages/api
     ports:


### PR DESCRIPTION
It was accidentally added back in cfcebf3b but we don't use it so it should not run