### PR TITLE
feat: Add example for longpolling

### DIFF
--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -679,6 +679,11 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
     "body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -1692,6 +1697,11 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "eventemitter2": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-3.0.0.tgz",
+      "integrity": "sha1-/saboLHN4nobsL1S31Sf1vZbD0U="
+    },
     "express": {
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
@@ -1752,6 +1762,16 @@
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
           "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
         }
+      }
+    },
+    "express-longpoll": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/express-longpoll/-/express-longpoll-0.0.6.tgz",
+      "integrity": "sha512-2weaYjDWNcHhno289OnYL5u/3DAZGoxUnfeSZQWDCrhoCB7nNv7kYitHR7+K7ZhILVYdkY1URH2vmaNFrDjLWw==",
+      "requires": {
+        "bluebird": "^3.5.0",
+        "eventemitter2": "3.0.0",
+        "lodash": ">=4.17.5"
       }
     },
     "express-openapi-validator": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -17,6 +17,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.17.1",
+    "express-longpoll": "0.0.6",
     "express-openapi-validator": "^4.10.8",
     "openapi-backend": "^3.7.0"
   },

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,9 +1,15 @@
 import OpenAPIBackend from 'openapi-backend'
 import express from 'express'
+import lp from 'express-longpoll'
 import * as routeHandlers from './routeHandlers'
 
 const app = express()
 app.use(express.json())
+
+const longpoll = lp(app, {DEBUG: true})
+longpoll.create("/poll")
+
+setInterval(() => longpoll.publish("/poll", {some_data: 1}), 5000)
 
 const api = new OpenAPIBackend({
   definition: './spec/predictivemovement.yaml',

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -6,6 +6,13 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "outDir": "dist"
-  }
+    "outDir": "dist",
+    "typeRoots": [
+      "./types", 
+      "node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "types"
+  ]
 }

--- a/packages/api/types/express-longpoll/index.d.ts
+++ b/packages/api/types/express-longpoll/index.d.ts
@@ -1,0 +1,12 @@
+declare module 'express-longpoll' {
+
+import type Express from 'express'
+
+interface Longpoll {
+  create: (path: string) => void,
+  publish: (path: string, payload: Object) => void
+}
+
+export default function lp(app: Express, config: Object): Longpoll
+
+}


### PR DESCRIPTION
I had a look at [express-longpoll](https://www.npmjs.com/package/express-longpoll) to verify that it works and see it working for myself.

There were no typings available for the package so I wrote up a quick module (it's just a guess tbh.)

This is the client code:

```es6
const fetch = require('node-fetch')

async function poll() {
	try {
		const response = await fetch('http://localhost:8000/poll').then(response => response.json())
		console.log({response});
		return poll();
	} catch (err) {
		console.error(err);
		return poll();
	}
}

poll();
```

<img width="1047" alt="Screenshot 2021-05-25 at 15 32 11" src="https://user-images.githubusercontent.com/646665/119506672-6d231500-bd6e-11eb-8cd4-a9fb642ce17d.png">
