### PR TITLE
wip: Custom long polling implementation

### DIFF
--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -331,6 +331,12 @@
         "@types/node": "*"
       }
     },
+    "@types/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
+      "dev": true
+    },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.14.0.tgz",
@@ -6937,8 +6943,7 @@
     "uuid": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-      "dev": true
+      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
     },
     "v8-compile-cache": {
       "version": "2.2.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -18,12 +18,14 @@
   "dependencies": {
     "express": "^4.17.1",
     "express-openapi-validator": "^4.10.8",
-    "openapi-backend": "^3.7.0"
+    "openapi-backend": "^3.7.0",
+    "uuid": "^7.0.3"
   },
   "devDependencies": {
     "@iteam/eslint-config-iteam-node": "^0.1.0",
     "@types/express": "^4.17.11",
     "@types/node": "^14.14.21",
+    "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^4.14.0",
     "@typescript-eslint/parser": "^4.14.0",
     "dredd": "^14.0.0",

--- a/packages/api/spec/predictivemovement.yaml
+++ b/packages/api/spec/predictivemovement.yaml
@@ -44,6 +44,17 @@ paths:
             application/json; charset=utf-8:
               schema:
                 $ref: "#/components/schemas/Itinerary"
+  /get_plan:
+    get:
+      operationId: get_plan
+      responses:
+        200:
+          description: OK
+          content:
+            application/json; charset=utf-8:
+              schema:
+                type: string
+
 components:
   schemas:
     Activity:

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,9 +1,17 @@
 import OpenAPIBackend from 'openapi-backend'
 import express from 'express'
 import * as routeHandlers from './routeHandlers'
+import { v4 as uuidv4 } from 'uuid'
+import longpoller from './poll'
 
 const app = express()
 app.use(express.json())
+
+app.use((req, res, next) => {
+  req.id = uuidv4()
+  req.poller = longpoller()
+  next()
+})
 
 const api = new OpenAPIBackend({
   definition: './spec/predictivemovement.yaml',
@@ -21,6 +29,7 @@ api.register({
     res.status(400).json({ err: context.validation.errors }),
   ...routeHandlers,
 })
+
 
 app.use((req, res, next) =>
   api.handleRequest(

--- a/packages/api/src/poll.ts
+++ b/packages/api/src/poll.ts
@@ -1,0 +1,47 @@
+import EventEmitter from 'events'
+
+// interface Config {
+//   log?: (msg: any) => void
+// }
+
+
+/**
+ * TODO:
+ 
+  Logging:
+    - .debug for all events that happen
+    - .debug for all subscriptions
+
+  Garbage collection:
+    - calls to `for` "expire" eventually, the listener should be removed
+ */
+
+export class Poll {
+  private ee: EventEmitter
+
+  constructor(EE: EventEmitter) {
+    this.ee = EE
+  }
+
+  /**
+   * Return the latest message for a certain channel
+   */
+  for = (eventId: string) : Promise<any> => {
+    return new Promise((resolve) => {
+      this.ee.once(eventId, resolve)
+    })
+  }
+
+  /**
+   * Publish a message to the channel
+   */
+  publish = (eventId: string, payload: Object) => {
+    this.ee.emit(eventId, payload)
+  }
+}
+
+export default function longpoll() {
+  const dispatcher = new EventEmitter()
+
+  return new Poll(dispatcher)
+}

--- a/packages/api/src/routeHandlers.ts
+++ b/packages/api/src/routeHandlers.ts
@@ -1,6 +1,7 @@
+import { Request } from 'express'
 import { Handler } from 'openapi-backend'
 
-export const get_transports: Handler = (c, req, res) => {
+export const get_transports: Handler = (c, req: Request, res) => {
   res.status(200).json([
     {
       transport_id: '',
@@ -18,8 +19,8 @@ export const get_transports: Handler = (c, req, res) => {
         name: '',
         position: {
           lat: 0,
-          lon: 0
-        }
+          lon: 0,
+        },
       },
       end_address: {
         city: '',
@@ -28,17 +29,13 @@ export const get_transports: Handler = (c, req, res) => {
         position: {
           lon: 0,
           lat: 0,
-        }
+        },
       },
     },
   ])
 }
 
-export const get_itinerary: Handler = (
-  c,
-  req,
-  res
-) => {
+export const get_itinerary: Handler = (c, req: Request, res) => {
   res.status(200).json({
     transport_id: c.request.params.transport_id,
     route: {},
@@ -57,3 +54,17 @@ export const get_itinerary: Handler = (
     ],
   })
 }
+
+export const get_plan: Handler = async (ctx, req: Request, res) => {
+  const {poller} = req 
+  
+  setTimeout(
+    () => poller.publish('plan', {my_great: 'plan'}),
+    1500
+  )
+  const msg = await poller.for('plan')
+  res.status(200).json(msg)
+
+  console.log(req.id, poller)
+}
+

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -6,6 +6,9 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "typeRoots": [
+      "./types"
+    ]
   }
 }

--- a/packages/api/types/express/index.d.ts
+++ b/packages/api/types/express/index.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Stuff we add to the express request object.
+ * Note that neither TS/Express will enforce that this is actually done.
+ */
+
+declare namespace Express {
+  import type { Poll } from '../../src/poll'
+
+  interface Request {
+    id: string
+    poller: Poll
+  }
+}


### PR DESCRIPTION
To avoid the following issues with express-longpoll:
- globals
- hijacking of the `app` (it adds it own routes)

I present a custom implementation. Some of the noice in here includes:
- Adding a typing of our Request object so that we can add stuff to it
- Add a `request.id` so that we can identify individual requests
- Add a Poll class that is wrapper on top of EventEmitter

Roughly inspired by: https://github.com/yehya/express-longpoll/blob/master/index.js

## TODO
- Garbage collection
- Logging
- Tests