### PR TITLE
fix: 🐛 engine k8s init container after elixir upgrade

### DIFF
--- a/packages/engine_umbrella/apps/engine/mix_tasks/release_tasks.ex
+++ b/packages/engine_umbrella/apps/engine/mix_tasks/release_tasks.ex
@@ -7,6 +7,6 @@ defmodule Engine.ReleaseTasks do
     config = Engine.ES.config()
 
     :ok = EventStore.Tasks.Create.exec(config, [])
-    :ok = EventStore.Tasks.Init.exec(Engine.ES, config, [])
+    :ok = EventStore.Tasks.Init.exec(config)
   end
 end


### PR DESCRIPTION
Fixes this mess:

```
 The EventStore schema already exists.
      > [engine-7b865b48f7-lhz8x engine-migrations] ** (UndefinedFunctionError) function EventStore.Tasks.Init.exec/3 is undefined or private. Did you mean one of:
      > [engine-7b865b48f7-lhz8x engine-migrations]       * exec/1
      > [engine-7b865b48f7-lhz8x engine-migrations]       * exec/2
 ...<HIDDEN CONTENT>...
      > [engine-7b865b48f7-lhz8x engine-migrations]     (engine 0.1.0) mix_tasks/release_tasks.ex:10: Engine.ReleaseTasks.init_event_store/0
      > [engine-7b865b48f7-lhz8x engine-migrations]     (stdlib 3.14.2) erl_eval.erl:680: :erl_eval.do_apply/6
      > [engine-7b865b48f7-lhz8x engine-migrations]     (elixir 1.11.4) lib/code.ex:341: Code.eval_string_with_error_handling/3
```